### PR TITLE
Fix building issue on aarch64

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -65,7 +65,7 @@ if [[ "$ARCH" = "x86_64" ]]; then
   fi
   GEAFLOW_IMAGE_NAME="geaflow"
   CONSOLE_IMAGE_NAME="geaflow-console"
-elif [[ "$ARCH" = "arm64" ]]; then
+elif [[ "$ARCH" = "arm64" || "$ARCH" = "aarch64" ]]; then
   if [[ "$USE_UBUNTU" = "true" ]]; then
     DOCKER_FILE="Dockerfile-arm64-ubuntu"
   else
@@ -74,7 +74,7 @@ elif [[ "$ARCH" = "arm64" ]]; then
   GEAFLOW_IMAGE_NAME="geaflow-arm"
   CONSOLE_IMAGE_NAME="geaflow-console-arm"
 else
-  echo -e "\033[31munknown arch $ARCH, only support x86_64,arm64\033[0m"
+  echo -e "\033[31munknown arch $ARCH, only support x86_64,arm64,aarch64\033[0m"
   exit 1
 fi
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

- `build.sh` determines the hardware architecture using the `uname -m `command.
- On some systems with 64-bit ARM architecture, running `uname -m` returns either aarch64 or arm64. Currently, `build.sh` only recognizes arm64 and fails to recognize aarch64.
- This update will fix the issue of failing to compile on aarch64 systems.

### How was this PR tested?
- [ ] Tests have Added for the changes
- [x] Production environment verified


