### PR TITLE
[asf] Remove publishing profile from .asf.yaml

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -17,9 +17,6 @@
 
 # See: https://cwiki.apache.org/confluence/display/INFRA/git+-+.asf.yaml+features
 
-publish:
-  whoami: asf-site
-
 github:
   description: "Apache GeaFlow: A Streaming Graph Computing Engine."
   homepage: https://geaflow.apache.org/


### PR DESCRIPTION
Remove publishing profile from .asf.yaml since we already have a separate website repo.
