### PR TITLE
docs: route vulnerability reports to the ASF security team

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,21 +4,16 @@
 
 The Apache Software Foundation takes security issues very seriously. We appreciate your efforts to responsibly disclose your findings.
 
-If you discover a security vulnerability in Apache GeaFlow (Incubating), please report it through one of the following methods:
+If you discover a security vulnerability in Apache GeaFlow (Incubating), please report it as follows:
 
 ### Email
 
-Please send your security vulnerability report to the Apache Security Team at:
-
-**[dev@geaflow.apache.org](mailto:dev@geaflow.apache.org)**
-
-You can also report to the GeaFlow project team directly at:
-
-**[private@geaflow.apache.org](mailto:private@geaflow.apache.org)**
+Please send your security vulnerability report to the Apache Security Team at
+[security@apache.org](mailto:security@apache.org?subject=%5BSECURITY%5D%20GeaFlow).
 
 ### What to Include
 
-When reporting a security vulnerability, please include the following information:
+When reporting a security vulnerability, please send one **plaintext** e-mail **per-finding** including the following information:
 
 - **Description**: A detailed description of the vulnerability
 - **Impact**: The potential impact and severity of the issue
@@ -27,12 +22,16 @@ When reporting a security vulnerability, please include the following informatio
 - **Proof of Concept**: If possible, provide a proof-of-concept or example code
 - **Suggested Fix**: If you have suggestions for fixing the issue, please include them
 
+See [reporting issues in ASF code](https://security.apache.org/report-code/) for more information.
+
 ### What to Expect
 
 - **Acknowledgment**: We will acknowledge receipt of your vulnerability report within 3 business days
 - **Updates**: We will send you updates on the progress of fixing the vulnerability
 - **Credit**: If you wish, we will credit you in the security advisory when the issue is fixed
 - **Timeline**: We aim to address critical security issues as quickly as possible, typically within 90 days
+
+See our [security handling policy](https://www.apache.org/security/committers.html#possible).
 
 ### Responsible Disclosure
 


### PR DESCRIPTION
## Problem

`SECURITY.md` currently asks reporters to send vulnerability reports to `dev@geaflow.apache.org`. That is a **publicly** archived mailing list, so anyone following our own instructions discloses the vulnerability to the world at the moment they report it, before the project has had any chance to fix it.

## Change

- Reports go to `security@apache.org` instead, with links to the ASF [reporting guide](https://security.apache.org/report-code/) and the [vulnerability handling policy](https://www.apache.org/security/committers.html#possible).
- Document the ASF submission conventions the security team expects: plaintext, one finding per e-mail.
- Drop `private@geaflow.apache.org`. To be clear, that list was not part of the leak (it is not publicly archived), it is removed only to keep a single entry point.

## Open question for the PPMC: which security address?

This is the part I would like discussed, since the PR picks one of two valid options and the project may prefer the other.

**Option A: request `security@geaflow.apache.org`.** Reports land directly on the project and the PPMC handles the whole lifecycle itself: triage, acknowledgement, CVE request, coordination with the reporter. Maximum control and no intermediate hop, but the project also absorbs everything that arrives, including the steady stream of automated scanner output and reports that are
not vulnerabilities at all.

**Option B (what this PR implements): point at `security@apache.org`.** The ASF Security Team takes a first pass before forwarding anything to us. That triage is admittedly very light on its own, mostly filtering the obviously invalid, and
it gets substantially more valuable once a project has documented a security model, because the team can then close out reports that fall outside that model without ever involving the project. See [Documenting your security model](https://cwiki.apache.org/confluence/spaces/SECURITY/pages/308153000/Documenting+your+security+model).

My suggestion is to merge Option B now, since it is strictly better than the status quo either way, and treat "write down GeaFlow's security model" as the follow-up that makes the choice actually pay off.

If the PPMC would rather own the whole flow, switching to Option A later is a one line change plus an INFRA ticket.
