### PR TITLE
feat(ai): define retrieval API v1 contract and configuration

### DIFF
--- a/geaflow-ai/src/main/java/org/apache/geaflow/ai/retrieval/api/model/ExecutionMode.java
+++ b/geaflow-ai/src/main/java/org/apache/geaflow/ai/retrieval/api/model/ExecutionMode.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.geaflow.ai.retrieval.api.model;
+
+/** Execution strategies reserved by the retrieval API. */
+public enum ExecutionMode {
+    SEQUENTIAL,
+    PARALLEL,
+    CASCADED
+}

--- a/geaflow-ai/src/main/java/org/apache/geaflow/ai/retrieval/api/model/RetrievalBudget.java
+++ b/geaflow-ai/src/main/java/org/apache/geaflow/ai/retrieval/api/model/RetrievalBudget.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.geaflow.ai.retrieval.api.model;
+
+/** Optional request budget and the effective budget returned in a response. */
+public class RetrievalBudget {
+
+    private Integer topK;
+    private Integer timeoutMs;
+    private Integer maxCandidates;
+    private Integer tokenBudget;
+
+    public RetrievalBudget() {
+    }
+
+    public RetrievalBudget(Integer topK, Integer timeoutMs, Integer maxCandidates,
+                           Integer tokenBudget) {
+        this.topK = topK;
+        this.timeoutMs = timeoutMs;
+        this.maxCandidates = maxCandidates;
+        this.tokenBudget = tokenBudget;
+    }
+
+    public Integer getTopK() {
+        return topK;
+    }
+
+    public void setTopK(Integer topK) {
+        this.topK = topK;
+    }
+
+    public Integer getTimeoutMs() {
+        return timeoutMs;
+    }
+
+    public void setTimeoutMs(Integer timeoutMs) {
+        this.timeoutMs = timeoutMs;
+    }
+
+    public Integer getMaxCandidates() {
+        return maxCandidates;
+    }
+
+    public void setMaxCandidates(Integer maxCandidates) {
+        this.maxCandidates = maxCandidates;
+    }
+
+    public Integer getTokenBudget() {
+        return tokenBudget;
+    }
+
+    public void setTokenBudget(Integer tokenBudget) {
+        this.tokenBudget = tokenBudget;
+    }
+}

--- a/geaflow-ai/src/main/java/org/apache/geaflow/ai/retrieval/api/model/RetrievalCommand.java
+++ b/geaflow-ai/src/main/java/org/apache/geaflow/ai/retrieval/api/model/RetrievalCommand.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.geaflow.ai.retrieval.api.model;
+
+/** Immutable request passed beyond the validation boundary. */
+public final class RetrievalCommand {
+
+    private final String graphName;
+    private final String query;
+    private final RetrievalMode mode;
+    private final ExecutionMode executionMode;
+    private final RetrievalBudget budget;
+
+    public RetrievalCommand(String graphName, String query, RetrievalMode mode,
+                            ExecutionMode executionMode, RetrievalBudget budget) {
+        this.graphName = graphName;
+        this.query = query;
+        this.mode = mode;
+        this.executionMode = executionMode;
+        this.budget = new RetrievalBudget(budget.getTopK(), budget.getTimeoutMs(),
+            budget.getMaxCandidates(), budget.getTokenBudget());
+    }
+
+    public String getGraphName() {
+        return graphName;
+    }
+
+    public String getQuery() {
+        return query;
+    }
+
+    public RetrievalMode getMode() {
+        return mode;
+    }
+
+    public ExecutionMode getExecutionMode() {
+        return executionMode;
+    }
+
+    public RetrievalBudget getBudget() {
+        return new RetrievalBudget(budget.getTopK(), budget.getTimeoutMs(),
+            budget.getMaxCandidates(), budget.getTokenBudget());
+    }
+}

--- a/geaflow-ai/src/main/java/org/apache/geaflow/ai/retrieval/api/model/RetrievalError.java
+++ b/geaflow-ai/src/main/java/org/apache/geaflow/ai/retrieval/api/model/RetrievalError.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.geaflow.ai.retrieval.api.model;
+
+/** Wire error response. Callers should branch on code, never message. */
+public class RetrievalError {
+
+    private String requestId;
+    private RetrievalErrorCode code;
+    private String message;
+    private boolean retriable;
+
+    public RetrievalError() {
+    }
+
+    public RetrievalError(String requestId, RetrievalErrorCode code, String message) {
+        this.requestId = requestId;
+        this.code = code;
+        this.message = message;
+        this.retriable = code != null && code.isRetriable();
+    }
+
+    public String getRequestId() {
+        return requestId;
+    }
+
+    public void setRequestId(String requestId) {
+        this.requestId = requestId;
+    }
+
+    public RetrievalErrorCode getCode() {
+        return code;
+    }
+
+    public void setCode(RetrievalErrorCode code) {
+        this.code = code;
+        this.retriable = code != null && code.isRetriable();
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public boolean isRetriable() {
+        return retriable;
+    }
+
+    public void setRetriable(boolean retriable) {
+        this.retriable = retriable;
+    }
+}

--- a/geaflow-ai/src/main/java/org/apache/geaflow/ai/retrieval/api/model/RetrievalErrorCode.java
+++ b/geaflow-ai/src/main/java/org/apache/geaflow/ai/retrieval/api/model/RetrievalErrorCode.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.geaflow.ai.retrieval.api.model;
+
+/** Stable machine-readable retrieval failure codes and HTTP semantics. */
+public enum RetrievalErrorCode {
+    INVALID_REQUEST(400, false),
+    UNSUPPORTED_OPTION(400, false),
+    GRAPH_NOT_FOUND(404, false),
+    INDEX_NOT_READY(503, true),
+    RETRIEVAL_TIMEOUT(504, true),
+    INTERNAL_ERROR(500, false);
+
+    private final int httpStatus;
+    private final boolean retriable;
+
+    RetrievalErrorCode(int httpStatus, boolean retriable) {
+        this.httpStatus = httpStatus;
+        this.retriable = retriable;
+    }
+
+    public int getHttpStatus() {
+        return httpStatus;
+    }
+
+    public boolean isRetriable() {
+        return retriable;
+    }
+}

--- a/geaflow-ai/src/main/java/org/apache/geaflow/ai/retrieval/api/model/RetrievalException.java
+++ b/geaflow-ai/src/main/java/org/apache/geaflow/ai/retrieval/api/model/RetrievalException.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.geaflow.ai.retrieval.api.model;
+
+/** Domain exception carrying a stable error code without exposing implementation details. */
+public class RetrievalException extends RuntimeException {
+
+    private final RetrievalErrorCode code;
+
+    public RetrievalException(RetrievalErrorCode code, String message) {
+        super(message);
+        this.code = code;
+    }
+
+    public RetrievalException(RetrievalErrorCode code, String message, Throwable cause) {
+        super(message, cause);
+        this.code = code;
+    }
+
+    public RetrievalErrorCode getCode() {
+        return code;
+    }
+
+    /** Alias used by adapters that expose the error code as a response field. */
+    public RetrievalErrorCode getErrorCode() {
+        return code;
+    }
+}

--- a/geaflow-ai/src/main/java/org/apache/geaflow/ai/retrieval/api/model/RetrievalMode.java
+++ b/geaflow-ai/src/main/java/org/apache/geaflow/ai/retrieval/api/model/RetrievalMode.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.geaflow.ai.retrieval.api.model;
+
+/** Retrieval modes understood by the versioned API. */
+public enum RetrievalMode {
+    KEYWORD
+}

--- a/geaflow-ai/src/main/java/org/apache/geaflow/ai/retrieval/api/model/RetrievalRequest.java
+++ b/geaflow-ai/src/main/java/org/apache/geaflow/ai/retrieval/api/model/RetrievalRequest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.geaflow.ai.retrieval.api.model;
+
+import java.util.List;
+
+/** Wire request DTO. Validation is performed by RetrievalRequestValidator. */
+public class RetrievalRequest {
+
+    private String graphName;
+    private String query;
+    private List<Double> queryVector;
+    private String mode;
+    private String executionMode;
+    private RetrievalBudget budget;
+
+    public RetrievalRequest() {
+    }
+
+    public String getGraphName() {
+        return graphName;
+    }
+
+    public void setGraphName(String graphName) {
+        this.graphName = graphName;
+    }
+
+    public String getQuery() {
+        return query;
+    }
+
+    public void setQuery(String query) {
+        this.query = query;
+    }
+
+    public List<Double> getQueryVector() {
+        return queryVector;
+    }
+
+    public void setQueryVector(List<Double> queryVector) {
+        this.queryVector = queryVector;
+    }
+
+    public String getMode() {
+        return mode;
+    }
+
+    public void setMode(String mode) {
+        this.mode = mode;
+    }
+
+    public String getExecutionMode() {
+        return executionMode;
+    }
+
+    public void setExecutionMode(String executionMode) {
+        this.executionMode = executionMode;
+    }
+
+    public RetrievalBudget getBudget() {
+        return budget;
+    }
+
+    public void setBudget(RetrievalBudget budget) {
+        this.budget = budget;
+    }
+}

--- a/geaflow-ai/src/main/java/org/apache/geaflow/ai/retrieval/api/model/RetrievalResponse.java
+++ b/geaflow-ai/src/main/java/org/apache/geaflow/ai/retrieval/api/model/RetrievalResponse.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.geaflow.ai.retrieval.api.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.geaflow.ai.retrieval.model.document.SourceRef;
+import org.apache.geaflow.ai.retrieval.model.evidence.Evidence;
+import org.apache.geaflow.ai.retrieval.model.graph.GraphPathRef;
+
+/** Wire success response DTO. */
+public class RetrievalResponse {
+
+    private String requestId;
+    private String graphName;
+    private String graphVersion;
+    private List<Evidence> evidence = new ArrayList<>();
+    private List<GraphPathRef> paths = new ArrayList<>();
+    private List<SourceRef> sources = new ArrayList<>();
+    private RetrievalTrace trace;
+    private RetrievalBudget effectiveBudget;
+    private List<String> degradedChannels = new ArrayList<>();
+
+    public RetrievalResponse() {
+    }
+
+    public String getRequestId() {
+        return requestId;
+    }
+
+    public void setRequestId(String requestId) {
+        this.requestId = requestId;
+    }
+
+    public String getGraphName() {
+        return graphName;
+    }
+
+    public void setGraphName(String graphName) {
+        this.graphName = graphName;
+    }
+
+    public String getGraphVersion() {
+        return graphVersion;
+    }
+
+    public void setGraphVersion(String graphVersion) {
+        this.graphVersion = graphVersion;
+    }
+
+    public List<Evidence> getEvidence() {
+        return evidence;
+    }
+
+    public void setEvidence(List<Evidence> evidence) {
+        this.evidence = evidence == null ? new ArrayList<Evidence>() : new ArrayList<>(evidence);
+    }
+
+    public List<GraphPathRef> getPaths() {
+        return paths;
+    }
+
+    public void setPaths(List<GraphPathRef> paths) {
+        this.paths = paths == null ? new ArrayList<GraphPathRef>() : new ArrayList<>(paths);
+    }
+
+    public List<SourceRef> getSources() {
+        return sources;
+    }
+
+    public void setSources(List<SourceRef> sources) {
+        this.sources = sources == null ? new ArrayList<SourceRef>() : new ArrayList<>(sources);
+    }
+
+    public RetrievalTrace getTrace() {
+        return trace;
+    }
+
+    public void setTrace(RetrievalTrace trace) {
+        this.trace = trace;
+    }
+
+    public RetrievalBudget getEffectiveBudget() {
+        return effectiveBudget;
+    }
+
+    public void setEffectiveBudget(RetrievalBudget effectiveBudget) {
+        this.effectiveBudget = effectiveBudget;
+    }
+
+    public List<String> getDegradedChannels() {
+        return degradedChannels;
+    }
+
+    public void setDegradedChannels(List<String> degradedChannels) {
+        this.degradedChannels = degradedChannels == null
+            ? new ArrayList<String>() : new ArrayList<>(degradedChannels);
+    }
+}

--- a/geaflow-ai/src/main/java/org/apache/geaflow/ai/retrieval/api/model/RetrievalTrace.java
+++ b/geaflow-ai/src/main/java/org/apache/geaflow/ai/retrieval/api/model/RetrievalTrace.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.geaflow.ai.retrieval.api.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** Stable minimum trace shape; future fields must be additive. */
+public class RetrievalTrace {
+
+    private String traceVersion;
+    private String originalQuery;
+    private RetrievalMode selectedMode;
+    private ExecutionMode executionMode;
+    private List<TraceStage> stages = new ArrayList<>();
+    private String stopReason;
+
+    public RetrievalTrace() {
+    }
+
+    public String getTraceVersion() {
+        return traceVersion;
+    }
+
+    public void setTraceVersion(String traceVersion) {
+        this.traceVersion = traceVersion;
+    }
+
+    public String getOriginalQuery() {
+        return originalQuery;
+    }
+
+    public void setOriginalQuery(String originalQuery) {
+        this.originalQuery = originalQuery;
+    }
+
+    public RetrievalMode getSelectedMode() {
+        return selectedMode;
+    }
+
+    public void setSelectedMode(RetrievalMode selectedMode) {
+        this.selectedMode = selectedMode;
+    }
+
+    public ExecutionMode getExecutionMode() {
+        return executionMode;
+    }
+
+    public void setExecutionMode(ExecutionMode executionMode) {
+        this.executionMode = executionMode;
+    }
+
+    public List<TraceStage> getStages() {
+        return stages;
+    }
+
+    public void setStages(List<TraceStage> stages) {
+        this.stages = stages == null ? new ArrayList<TraceStage>() : new ArrayList<>(stages);
+    }
+
+    public String getStopReason() {
+        return stopReason;
+    }
+
+    public void setStopReason(String stopReason) {
+        this.stopReason = stopReason;
+    }
+}

--- a/geaflow-ai/src/main/java/org/apache/geaflow/ai/retrieval/api/model/TraceStage.java
+++ b/geaflow-ai/src/main/java/org/apache/geaflow/ai/retrieval/api/model/TraceStage.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.geaflow.ai.retrieval.api.model;
+
+/** Minimal, additive trace stage description. */
+public class TraceStage {
+
+    private String name;
+    private String status;
+    private String reason;
+
+    public TraceStage() {
+    }
+
+    public TraceStage(String name, String status, String reason) {
+        this.name = name;
+        this.status = status;
+        this.reason = reason;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+
+    public void setReason(String reason) {
+        this.reason = reason;
+    }
+}

--- a/geaflow-ai/src/main/java/org/apache/geaflow/ai/retrieval/api/package-info.java
+++ b/geaflow-ai/src/main/java/org/apache/geaflow/ai/retrieval/api/package-info.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Versioned retrieval API contract for Java and HTTP clients.
+ *
+ * <p>Version {@code v1} supports {@code KEYWORD} retrieval with {@code SEQUENTIAL} execution.
+ * {@code PARALLEL}, {@code CASCADED}, and non-empty query vectors are reserved and must be
+ * reported as {@code UNSUPPORTED_OPTION}. Unknown JSON fields are accepted for additive wire
+ * compatibility; duplicate fields are rejected. Response collections are always JSON arrays.</p>
+ *
+ * <p>Error codes map to HTTP status as follows: {@code INVALID_REQUEST}=400,
+ * {@code UNSUPPORTED_OPTION}=400, {@code GRAPH_NOT_FOUND}=404,
+ * {@code INDEX_NOT_READY}=503, {@code RETRIEVAL_TIMEOUT}=504, and
+ * {@code INTERNAL_ERROR}=500. Only {@code INDEX_NOT_READY} and {@code RETRIEVAL_TIMEOUT} are
+ * retriable.</p>
+ */
+package org.apache.geaflow.ai.retrieval.api;

--- a/geaflow-ai/src/main/java/org/apache/geaflow/ai/retrieval/codec/RetrievalApiJson.java
+++ b/geaflow-ai/src/main/java/org/apache/geaflow/ai/retrieval/codec/RetrievalApiJson.java
@@ -27,6 +27,7 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
 import java.io.IOException;
 import java.io.StringReader;
+import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
@@ -43,21 +44,29 @@ import org.apache.geaflow.ai.retrieval.model.document.SourceRef;
 import org.apache.geaflow.ai.retrieval.model.evidence.Evidence;
 import org.apache.geaflow.ai.retrieval.model.graph.GraphPathRef;
 import org.apache.geaflow.ai.retrieval.service.RetrievalErrorValidator;
+import org.apache.geaflow.ai.retrieval.service.RetrievalRequestValidator;
 import org.apache.geaflow.ai.retrieval.service.RetrievalResponseValidator;
 
 /** Strict, dependency-light JSON boundary for the v1 retrieval API. */
 public final class RetrievalApiJson {
 
     private static final int MAX_JSON_LENGTH = 1024 * 1024;
+    private static final int MAX_JSON_DEPTH = 256;
     private static final Gson GSON = new Gson();
 
     private RetrievalApiJson() {
     }
 
     public static RetrievalRequest parseRequest(String json) {
+        return parseRequest(json, defaultProperties());
+    }
+
+    public static RetrievalRequest parseRequest(String json, RetrievalProperties properties) {
         JsonObject object = object(json);
         validateRequestShape(object);
-        return GSON.fromJson(object, RetrievalRequest.class);
+        RetrievalRequest request = GSON.fromJson(object, RetrievalRequest.class);
+        new RetrievalRequestValidator(properties).validate(request);
+        return request;
     }
 
     public static RetrievalResponse parseResponse(String json) {
@@ -126,6 +135,8 @@ public final class RetrievalApiJson {
             RetrievalResponseValidator.validate((RetrievalResponse) value, properties);
         } else if (value instanceof RetrievalError) {
             RetrievalErrorValidator.validate((RetrievalError) value);
+        } else if (value instanceof RetrievalRequest) {
+            new RetrievalRequestValidator(properties).validate((RetrievalRequest) value);
         }
         return GSON.toJson(value);
     }
@@ -284,12 +295,11 @@ public final class RetrievalApiJson {
         if (!element.isJsonPrimitive() || !element.getAsJsonPrimitive().isNumber()) {
             throw new JsonParseException(name + " must be an integer");
         }
-        double value = element.getAsDouble();
-        if (!Double.isFinite(value) || value != Math.rint(value)
-            || value < Integer.MIN_VALUE || value > Integer.MAX_VALUE) {
+        try {
+            return new BigDecimal(element.getAsString()).intValueExact();
+        } catch (NumberFormatException | ArithmeticException e) {
             throw new JsonParseException(name + " must be an integer");
         }
-        return (int) value;
     }
 
     private static String string(JsonObject object, String name) {
@@ -344,7 +354,7 @@ public final class RetrievalApiJson {
         JsonReader reader = new JsonReader(new StringReader(json));
         reader.setLenient(false);
         try {
-            consume(reader);
+            consume(reader, 0);
             if (reader.peek() != JsonToken.END_DOCUMENT) {
                 throw new JsonParseException("trailing JSON content");
             }
@@ -353,9 +363,10 @@ public final class RetrievalApiJson {
         }
     }
 
-    private static void consume(JsonReader reader) throws IOException {
+    private static void consume(JsonReader reader, int depth) throws IOException {
         JsonToken token = reader.peek();
         if (token == JsonToken.BEGIN_OBJECT) {
+            int childDepth = nextDepth(depth);
             java.util.HashSet<String> names = new java.util.HashSet<>();
             reader.beginObject();
             while (reader.hasNext()) {
@@ -363,13 +374,14 @@ public final class RetrievalApiJson {
                 if (!names.add(name)) {
                     throw new JsonParseException("duplicate JSON field: " + name);
                 }
-                consume(reader);
+                consume(reader, childDepth);
             }
             reader.endObject();
         } else if (token == JsonToken.BEGIN_ARRAY) {
+            int childDepth = nextDepth(depth);
             reader.beginArray();
             while (reader.hasNext()) {
-                consume(reader);
+                consume(reader, childDepth);
             }
             reader.endArray();
         } else if (token == JsonToken.STRING) {
@@ -383,5 +395,12 @@ public final class RetrievalApiJson {
         } else {
             throw new JsonParseException("invalid JSON token: " + token);
         }
+    }
+
+    private static int nextDepth(int depth) {
+        if (depth >= MAX_JSON_DEPTH) {
+            throw new JsonParseException("retrieval JSON exceeds maximum nesting depth");
+        }
+        return depth + 1;
     }
 }

--- a/geaflow-ai/src/main/java/org/apache/geaflow/ai/retrieval/codec/RetrievalApiJson.java
+++ b/geaflow-ai/src/main/java/org/apache/geaflow/ai/retrieval/codec/RetrievalApiJson.java
@@ -1,0 +1,366 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.geaflow.ai.retrieval.codec;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonParser;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import java.io.IOException;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.geaflow.ai.retrieval.api.model.ExecutionMode;
+import org.apache.geaflow.ai.retrieval.api.model.RetrievalBudget;
+import org.apache.geaflow.ai.retrieval.api.model.RetrievalError;
+import org.apache.geaflow.ai.retrieval.api.model.RetrievalErrorCode;
+import org.apache.geaflow.ai.retrieval.api.model.RetrievalRequest;
+import org.apache.geaflow.ai.retrieval.api.model.RetrievalResponse;
+import org.apache.geaflow.ai.retrieval.api.model.RetrievalTrace;
+import org.apache.geaflow.ai.retrieval.api.model.TraceStage;
+import org.apache.geaflow.ai.retrieval.model.document.SourceRef;
+import org.apache.geaflow.ai.retrieval.model.evidence.Evidence;
+import org.apache.geaflow.ai.retrieval.model.graph.GraphPathRef;
+
+/** Strict, dependency-light JSON boundary for the v1 retrieval API. */
+public final class RetrievalApiJson {
+
+    private static final int MAX_JSON_LENGTH = 1024 * 1024;
+    private static final Gson GSON = new Gson();
+
+    private RetrievalApiJson() {
+    }
+
+    public static RetrievalRequest parseRequest(String json) {
+        JsonObject object = object(json);
+        validateRequestShape(object);
+        return GSON.fromJson(object, RetrievalRequest.class);
+    }
+
+    public static RetrievalResponse parseResponse(String json) {
+        JsonObject object = object(json);
+        requireString(object, "requestId");
+        requireString(object, "graphName");
+        requireString(object, "graphVersion");
+        requireArray(object, "evidence");
+        requireArray(object, "paths");
+        requireArray(object, "sources");
+        requireArray(object, "degradedChannels");
+        requireObject(object, "trace");
+        requireObject(object, "effectiveBudget");
+        List<Evidence> evidence = models(object, "evidence", Evidence.class);
+        List<GraphPathRef> paths = models(object, "paths", GraphPathRef.class);
+        List<SourceRef> sources = models(object, "sources", SourceRef.class);
+        RetrievalResponse response = new RetrievalResponse();
+        response.setRequestId(object.get("requestId").getAsString());
+        response.setGraphName(object.get("graphName").getAsString());
+        response.setGraphVersion(object.get("graphVersion").getAsString());
+        response.setEvidence(evidence);
+        response.setPaths(paths);
+        response.setSources(sources);
+        response.setTrace(parseTrace(object.getAsJsonObject("trace")));
+        response.setEffectiveBudget(parseBudget(object.getAsJsonObject("effectiveBudget"), true));
+        response.setDegradedChannels(strings(object, "degradedChannels"));
+        return response;
+    }
+
+    public static RetrievalError parseError(String json) {
+        JsonObject object = object(json);
+        requireString(object, "requestId");
+        requireString(object, "code");
+        requireString(object, "message");
+        String code = object.get("code").getAsString();
+        RetrievalErrorCode errorCode;
+        try {
+            errorCode = RetrievalErrorCode.valueOf(code);
+        } catch (IllegalArgumentException e) {
+            throw new JsonParseException("unknown retrieval error code: " + code);
+        }
+        if (!object.has("retriable") || !object.get("retriable").isJsonPrimitive()
+            || !object.get("retriable").getAsJsonPrimitive().isBoolean()) {
+            throw new JsonParseException("retriable is required and must be boolean");
+        }
+        boolean retriable = object.get("retriable").getAsBoolean();
+        if (retriable != errorCode.isRetriable()) {
+            throw new JsonParseException("retriable does not match error code");
+        }
+        RetrievalError error = new RetrievalError(object.get("requestId").getAsString(),
+            errorCode, object.get("message").getAsString());
+        error.setRetriable(retriable);
+        return error;
+    }
+
+    public static String toJson(Object value) {
+        return GSON.toJson(value);
+    }
+
+    private static JsonObject object(String json) {
+        if (json == null || json.trim().isEmpty()) {
+            throw new JsonParseException("JSON object is required");
+        }
+        if (json.getBytes(StandardCharsets.UTF_8).length > MAX_JSON_LENGTH) {
+            throw new JsonParseException("retrieval JSON exceeds maximum size");
+        }
+        try {
+            rejectDuplicateKeys(json);
+            JsonElement element = new JsonParser().parse(json);
+            if (!element.isJsonObject()) {
+                throw new JsonParseException("retrieval JSON must be an object");
+            }
+            return element.getAsJsonObject();
+        } catch (JsonParseException e) {
+            throw e;
+        } catch (RuntimeException e) {
+            throw new JsonParseException("invalid retrieval JSON", e);
+        }
+    }
+
+    private static void validateRequestShape(JsonObject object) {
+        requireString(object, "graphName");
+        requireString(object, "query");
+        optionalString(object, "mode");
+        optionalString(object, "executionMode");
+        if (object.has("queryVector") && !object.get("queryVector").isJsonNull()) {
+            JsonElement value = object.get("queryVector");
+            if (!value.isJsonArray()) {
+                throw new JsonParseException("queryVector must be an array");
+            }
+            for (JsonElement item : value.getAsJsonArray()) {
+                if (!item.isJsonPrimitive() || !item.getAsJsonPrimitive().isNumber()
+                    || !Double.isFinite(item.getAsDouble())) {
+                    throw new JsonParseException("queryVector must contain finite numbers");
+                }
+            }
+        }
+        if (object.has("budget") && !object.get("budget").isJsonNull()) {
+            requireObject(object, "budget");
+            parseBudget(object.getAsJsonObject("budget"), false);
+        }
+    }
+
+    private static RetrievalBudget parseBudget(JsonObject object, boolean requiredValues) {
+        if (object == null) {
+            throw new JsonParseException("budget must be an object");
+        }
+        Integer topK = optionalInt(object, "topK");
+        Integer timeoutMs = optionalInt(object, "timeoutMs");
+        Integer maxCandidates = optionalInt(object, "maxCandidates");
+        Integer tokenBudget = optionalInt(object, "tokenBudget");
+        if (requiredValues && (topK == null || timeoutMs == null || maxCandidates == null
+            || tokenBudget == null || topK < 1 || timeoutMs < 1 || maxCandidates < 1
+            || tokenBudget < 1 || topK > maxCandidates)) {
+            throw new JsonParseException("effectiveBudget contains invalid values");
+        }
+        return new RetrievalBudget(topK, timeoutMs, maxCandidates, tokenBudget);
+    }
+
+    private static RetrievalTrace parseTrace(JsonObject object) {
+        if (object == null) {
+            throw new JsonParseException("trace must be an object");
+        }
+        RetrievalTrace trace = new RetrievalTrace();
+        trace.setTraceVersion(string(object, "traceVersion"));
+        trace.setOriginalQuery(string(object, "originalQuery"));
+        trace.setSelectedMode(enumValue(object, "selectedMode",
+            org.apache.geaflow.ai.retrieval.api.model.RetrievalMode.class));
+        trace.setExecutionMode(enumValue(object, "executionMode", ExecutionMode.class));
+        requireArray(object, "stages");
+        trace.setStages(traceStages(object, "stages"));
+        trace.setStopReason(optionalString(object, "stopReason"));
+        return trace;
+    }
+
+    private static List<TraceStage> traceStages(JsonObject object, String name) {
+        JsonElement element = object.get(name);
+        if (element == null || element.isJsonNull()) {
+            return new ArrayList<>();
+        }
+        if (!element.isJsonArray()) {
+            throw new JsonParseException(name + " must be an array");
+        }
+        List<TraceStage> result = new ArrayList<>();
+        for (JsonElement item : element.getAsJsonArray()) {
+            if (!item.isJsonObject()) {
+                throw new JsonParseException(name + " elements must be objects");
+            }
+            JsonObject stage = item.getAsJsonObject();
+            result.add(new TraceStage(string(stage, "name"), string(stage, "status"),
+                optionalString(stage, "reason")));
+        }
+        return result;
+    }
+
+    private static <T> List<T> models(JsonObject object, String name, Class<T> type) {
+        JsonElement element = object.get(name);
+        if (element == null || element.isJsonNull()) {
+            return new ArrayList<>();
+        }
+        if (!element.isJsonArray()) {
+            throw new JsonParseException(name + " must be an array");
+        }
+        List<T> result = new ArrayList<>();
+        for (JsonElement item : element.getAsJsonArray()) {
+            if (!item.isJsonObject()) {
+                throw new JsonParseException(name + " elements must be objects");
+            }
+            String itemJson = item.toString();
+            if (type == Evidence.class) {
+                result.add(type.cast(RetrievalModelJson.fromJson(itemJson, Evidence.class)));
+            } else if (type == GraphPathRef.class) {
+                result.add(type.cast(RetrievalModelJson.fromJson(itemJson, GraphPathRef.class)));
+            } else if (type == SourceRef.class) {
+                result.add(type.cast(RetrievalModelJson.fromJson(itemJson, SourceRef.class)));
+            } else {
+                result.add(GSON.fromJson(item, type));
+            }
+        }
+        return result;
+    }
+
+    private static List<String> strings(JsonObject object, String name) {
+        JsonElement element = object.get(name);
+        if (element == null || element.isJsonNull()) {
+            return new ArrayList<>();
+        }
+        if (!element.isJsonArray()) {
+            throw new JsonParseException(name + " must be an array");
+        }
+        List<String> result = new ArrayList<>();
+        for (JsonElement item : element.getAsJsonArray()) {
+            if (!item.isJsonPrimitive() || !item.getAsJsonPrimitive().isString()) {
+                throw new JsonParseException(name + " must contain strings");
+            }
+            result.add(item.getAsString());
+        }
+        return result;
+    }
+
+    private static Integer optionalInt(JsonObject object, String name) {
+        JsonElement element = object.get(name);
+        if (element == null || element.isJsonNull()) {
+            return null;
+        }
+        if (!element.isJsonPrimitive() || !element.getAsJsonPrimitive().isNumber()) {
+            throw new JsonParseException(name + " must be an integer");
+        }
+        double value = element.getAsDouble();
+        if (!Double.isFinite(value) || value != Math.rint(value)
+            || value < Integer.MIN_VALUE || value > Integer.MAX_VALUE) {
+            throw new JsonParseException(name + " must be an integer");
+        }
+        return (int) value;
+    }
+
+    private static String string(JsonObject object, String name) {
+        requireString(object, name);
+        return object.get(name).getAsString();
+    }
+
+    private static String requireString(JsonObject object, String name) {
+        JsonElement element = object.get(name);
+        if (element == null || element.isJsonNull() || !element.isJsonPrimitive()
+            || !element.getAsJsonPrimitive().isString()) {
+            throw new JsonParseException(name + " is required and must be a string");
+        }
+        return element.getAsString();
+    }
+
+    private static void requireArray(JsonObject object, String name) {
+        JsonElement element = object.get(name);
+        if (element == null || element.isJsonNull() || !element.isJsonArray()) {
+            throw new JsonParseException(name + " is required and must be an array");
+        }
+    }
+
+    private static void requireObject(JsonObject object, String name) {
+        JsonElement element = object.get(name);
+        if (element == null || element.isJsonNull() || !element.isJsonObject()) {
+            throw new JsonParseException(name + " is required and must be an object");
+        }
+    }
+
+    private static String optionalString(JsonObject object, String name) {
+        JsonElement element = object.get(name);
+        if (element == null || element.isJsonNull()) {
+            return null;
+        }
+        if (!element.isJsonPrimitive() || !element.getAsJsonPrimitive().isString()) {
+            throw new JsonParseException(name + " must be a string");
+        }
+        return element.getAsString();
+    }
+
+    private static <T extends Enum<T>> T enumValue(JsonObject object, String name, Class<T> type) {
+        String value = string(object, name);
+        try {
+            return Enum.valueOf(type, value);
+        } catch (IllegalArgumentException e) {
+            throw new JsonParseException("unknown " + name + ": " + value);
+        }
+    }
+
+    private static void rejectDuplicateKeys(String json) {
+        JsonReader reader = new JsonReader(new StringReader(json));
+        reader.setLenient(false);
+        try {
+            consume(reader);
+            if (reader.peek() != JsonToken.END_DOCUMENT) {
+                throw new JsonParseException("trailing JSON content");
+            }
+        } catch (IOException e) {
+            throw new JsonParseException("invalid JSON", e);
+        }
+    }
+
+    private static void consume(JsonReader reader) throws IOException {
+        JsonToken token = reader.peek();
+        if (token == JsonToken.BEGIN_OBJECT) {
+            java.util.HashSet<String> names = new java.util.HashSet<>();
+            reader.beginObject();
+            while (reader.hasNext()) {
+                String name = reader.nextName();
+                if (!names.add(name)) {
+                    throw new JsonParseException("duplicate JSON field: " + name);
+                }
+                consume(reader);
+            }
+            reader.endObject();
+        } else if (token == JsonToken.BEGIN_ARRAY) {
+            reader.beginArray();
+            while (reader.hasNext()) {
+                consume(reader);
+            }
+            reader.endArray();
+        } else if (token == JsonToken.STRING) {
+            reader.nextString();
+        } else if (token == JsonToken.NUMBER) {
+            reader.nextString();
+        } else if (token == JsonToken.BOOLEAN) {
+            reader.nextBoolean();
+        } else if (token == JsonToken.NULL) {
+            reader.nextNull();
+        } else {
+            throw new JsonParseException("invalid JSON token: " + token);
+        }
+    }
+}

--- a/geaflow-ai/src/main/java/org/apache/geaflow/ai/retrieval/codec/RetrievalApiJson.java
+++ b/geaflow-ai/src/main/java/org/apache/geaflow/ai/retrieval/codec/RetrievalApiJson.java
@@ -38,9 +38,12 @@ import org.apache.geaflow.ai.retrieval.api.model.RetrievalRequest;
 import org.apache.geaflow.ai.retrieval.api.model.RetrievalResponse;
 import org.apache.geaflow.ai.retrieval.api.model.RetrievalTrace;
 import org.apache.geaflow.ai.retrieval.api.model.TraceStage;
+import org.apache.geaflow.ai.retrieval.config.RetrievalProperties;
 import org.apache.geaflow.ai.retrieval.model.document.SourceRef;
 import org.apache.geaflow.ai.retrieval.model.evidence.Evidence;
 import org.apache.geaflow.ai.retrieval.model.graph.GraphPathRef;
+import org.apache.geaflow.ai.retrieval.service.RetrievalErrorValidator;
+import org.apache.geaflow.ai.retrieval.service.RetrievalResponseValidator;
 
 /** Strict, dependency-light JSON boundary for the v1 retrieval API. */
 public final class RetrievalApiJson {
@@ -58,6 +61,10 @@ public final class RetrievalApiJson {
     }
 
     public static RetrievalResponse parseResponse(String json) {
+        return parseResponse(json, defaultProperties());
+    }
+
+    public static RetrievalResponse parseResponse(String json, RetrievalProperties properties) {
         JsonObject object = object(json);
         requireString(object, "requestId");
         requireString(object, "graphName");
@@ -81,7 +88,7 @@ public final class RetrievalApiJson {
         response.setTrace(parseTrace(object.getAsJsonObject("trace")));
         response.setEffectiveBudget(parseBudget(object.getAsJsonObject("effectiveBudget"), true));
         response.setDegradedChannels(strings(object, "degradedChannels"));
-        return response;
+        return RetrievalResponseValidator.validate(response, properties);
     }
 
     public static RetrievalError parseError(String json) {
@@ -107,11 +114,26 @@ public final class RetrievalApiJson {
         RetrievalError error = new RetrievalError(object.get("requestId").getAsString(),
             errorCode, object.get("message").getAsString());
         error.setRetriable(retriable);
-        return error;
+        return RetrievalErrorValidator.validate(error);
     }
 
     public static String toJson(Object value) {
+        return toJson(value, defaultProperties());
+    }
+
+    public static String toJson(Object value, RetrievalProperties properties) {
+        if (value instanceof RetrievalResponse) {
+            RetrievalResponseValidator.validate((RetrievalResponse) value, properties);
+        } else if (value instanceof RetrievalError) {
+            RetrievalErrorValidator.validate((RetrievalError) value);
+        }
         return GSON.toJson(value);
+    }
+
+    private static RetrievalProperties defaultProperties() {
+        RetrievalProperties properties = new RetrievalProperties();
+        properties.validateConfiguration();
+        return properties;
     }
 
     private static JsonObject object(String json) {
@@ -167,8 +189,7 @@ public final class RetrievalApiJson {
         Integer maxCandidates = optionalInt(object, "maxCandidates");
         Integer tokenBudget = optionalInt(object, "tokenBudget");
         if (requiredValues && (topK == null || timeoutMs == null || maxCandidates == null
-            || tokenBudget == null || topK < 1 || timeoutMs < 1 || maxCandidates < 1
-            || tokenBudget < 1 || topK > maxCandidates)) {
+            || tokenBudget == null)) {
             throw new JsonParseException("effectiveBudget contains invalid values");
         }
         return new RetrievalBudget(topK, timeoutMs, maxCandidates, tokenBudget);

--- a/geaflow-ai/src/main/java/org/apache/geaflow/ai/retrieval/config/RetrievalProperties.java
+++ b/geaflow-ai/src/main/java/org/apache/geaflow/ai/retrieval/config/RetrievalProperties.java
@@ -56,10 +56,10 @@ public class RetrievalProperties {
 
     @Init
     public void validateConfiguration() {
-        if (blank(configVersion) || blank(readyGraphName)) {
+        if (!"v1".equals(configVersion) || blank(readyGraphName)) {
             throw new RetrievalException(
                 org.apache.geaflow.ai.retrieval.api.model.RetrievalErrorCode.INVALID_REQUEST,
-                "retrieval config-version and ready-graph-name are required");
+                "retrieval config-version must be v1 and ready-graph-name is required");
         }
         if (!RetrievalMode.KEYWORD.name().equals(defaultMode)) {
             throw invalid("default-mode must be KEYWORD");

--- a/geaflow-ai/src/main/java/org/apache/geaflow/ai/retrieval/config/RetrievalProperties.java
+++ b/geaflow-ai/src/main/java/org/apache/geaflow/ai/retrieval/config/RetrievalProperties.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.geaflow.ai.retrieval.config;
+
+import org.apache.geaflow.ai.retrieval.api.model.ExecutionMode;
+import org.apache.geaflow.ai.retrieval.api.model.RetrievalException;
+import org.apache.geaflow.ai.retrieval.api.model.RetrievalMode;
+import org.noear.solon.annotation.Component;
+import org.noear.solon.annotation.Init;
+import org.noear.solon.annotation.Inject;
+
+/** Versioned defaults and hard limits for retrieval requests. */
+@Component
+public class RetrievalProperties {
+
+    @Inject("${retrieval.config-version:v1}")
+    private String configVersion = "v1";
+    @Inject("${retrieval.ready-graph-name:Confucius}")
+    private String readyGraphName = "Confucius";
+    @Inject("${retrieval.default-mode:KEYWORD}")
+    private String defaultMode = "KEYWORD";
+    @Inject("${retrieval.default-execution-mode:SEQUENTIAL}")
+    private String defaultExecutionMode = "SEQUENTIAL";
+    @Inject("${retrieval.default-top-k:10}")
+    private int defaultTopK = 10;
+    @Inject("${retrieval.max-top-k:100}")
+    private int maxTopK = 100;
+    @Inject("${retrieval.default-timeout-ms:3000}")
+    private int defaultTimeoutMs = 3000;
+    @Inject("${retrieval.max-timeout-ms:10000}")
+    private int maxTimeoutMs = 10000;
+    @Inject("${retrieval.default-max-candidates:100}")
+    private int defaultMaxCandidates = 100;
+    @Inject("${retrieval.max-candidates:1000}")
+    private int maxCandidates = 1000;
+    @Inject("${retrieval.default-token-budget:4096}")
+    private int defaultTokenBudget = 4096;
+    @Inject("${retrieval.max-token-budget:16384}")
+    private int maxTokenBudget = 16384;
+
+    @Init
+    public void validateConfiguration() {
+        if (blank(configVersion) || blank(readyGraphName)) {
+            throw new RetrievalException(
+                org.apache.geaflow.ai.retrieval.api.model.RetrievalErrorCode.INVALID_REQUEST,
+                "retrieval config-version and ready-graph-name are required");
+        }
+        if (!RetrievalMode.KEYWORD.name().equals(defaultMode)) {
+            throw invalid("default-mode must be KEYWORD");
+        }
+        if (!ExecutionMode.SEQUENTIAL.name().equals(defaultExecutionMode)) {
+            throw invalid("default-execution-mode must be SEQUENTIAL");
+        }
+        positiveLimit(defaultTopK, maxTopK, "topK");
+        positiveLimit(defaultTimeoutMs, maxTimeoutMs, "timeoutMs");
+        positiveLimit(defaultMaxCandidates, maxCandidates, "maxCandidates");
+        positiveLimit(defaultTokenBudget, maxTokenBudget, "tokenBudget");
+        if (defaultTopK > defaultMaxCandidates) {
+            throw invalid("default-top-k must not exceed default-max-candidates");
+        }
+    }
+
+    private static void positiveLimit(int defaultValue, int maxValue, String name) {
+        if (defaultValue < 1 || maxValue < 1 || defaultValue > maxValue) {
+            throw invalid("invalid " + name + " default or hard limit");
+        }
+    }
+
+    private static boolean blank(String value) {
+        return value == null || value.trim().isEmpty();
+    }
+
+    private static RetrievalException invalid(String message) {
+        return new RetrievalException(
+            org.apache.geaflow.ai.retrieval.api.model.RetrievalErrorCode.INVALID_REQUEST, message);
+    }
+
+    public String getConfigVersion() {
+        return configVersion;
+    }
+
+    public void setConfigVersion(String configVersion) {
+        this.configVersion = configVersion;
+    }
+
+    public String getReadyGraphName() {
+        return readyGraphName;
+    }
+
+    public void setReadyGraphName(String readyGraphName) {
+        this.readyGraphName = readyGraphName;
+    }
+
+    public String getDefaultMode() {
+        return defaultMode;
+    }
+
+    public void setDefaultMode(String defaultMode) {
+        this.defaultMode = defaultMode;
+    }
+
+    public String getDefaultExecutionMode() {
+        return defaultExecutionMode;
+    }
+
+    public void setDefaultExecutionMode(String defaultExecutionMode) {
+        this.defaultExecutionMode = defaultExecutionMode;
+    }
+
+    public int getDefaultTopK() {
+        return defaultTopK;
+    }
+
+    public void setDefaultTopK(int defaultTopK) {
+        this.defaultTopK = defaultTopK;
+    }
+
+    public int getMaxTopK() {
+        return maxTopK;
+    }
+
+    public void setMaxTopK(int maxTopK) {
+        this.maxTopK = maxTopK;
+    }
+
+    public int getDefaultTimeoutMs() {
+        return defaultTimeoutMs;
+    }
+
+    public void setDefaultTimeoutMs(int defaultTimeoutMs) {
+        this.defaultTimeoutMs = defaultTimeoutMs;
+    }
+
+    public int getMaxTimeoutMs() {
+        return maxTimeoutMs;
+    }
+
+    public void setMaxTimeoutMs(int maxTimeoutMs) {
+        this.maxTimeoutMs = maxTimeoutMs;
+    }
+
+    public int getDefaultMaxCandidates() {
+        return defaultMaxCandidates;
+    }
+
+    public void setDefaultMaxCandidates(int defaultMaxCandidates) {
+        this.defaultMaxCandidates = defaultMaxCandidates;
+    }
+
+    public int getMaxCandidates() {
+        return maxCandidates;
+    }
+
+    public void setMaxCandidates(int maxCandidates) {
+        this.maxCandidates = maxCandidates;
+    }
+
+    public int getDefaultTokenBudget() {
+        return defaultTokenBudget;
+    }
+
+    public void setDefaultTokenBudget(int defaultTokenBudget) {
+        this.defaultTokenBudget = defaultTokenBudget;
+    }
+
+    public int getMaxTokenBudget() {
+        return maxTokenBudget;
+    }
+
+    public void setMaxTokenBudget(int maxTokenBudget) {
+        this.maxTokenBudget = maxTokenBudget;
+    }
+}

--- a/geaflow-ai/src/main/java/org/apache/geaflow/ai/retrieval/service/RetrievalBudgetValidator.java
+++ b/geaflow-ai/src/main/java/org/apache/geaflow/ai/retrieval/service/RetrievalBudgetValidator.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.geaflow.ai.retrieval.service;
+
+import org.apache.geaflow.ai.retrieval.api.model.RetrievalBudget;
+import org.apache.geaflow.ai.retrieval.api.model.RetrievalErrorCode;
+import org.apache.geaflow.ai.retrieval.api.model.RetrievalException;
+import org.apache.geaflow.ai.retrieval.config.RetrievalProperties;
+
+/** Applies the same budget invariants at every API boundary. */
+public final class RetrievalBudgetValidator {
+
+    private RetrievalBudgetValidator() {
+    }
+
+    public static RetrievalBudget validate(RetrievalBudget budget, RetrievalProperties properties,
+                                           boolean requireAllValues) {
+        if (budget == null) {
+            if (requireAllValues) {
+                throw invalid("budget is required");
+            }
+            return defaults(properties);
+        }
+        Integer topK = valueOrDefault(budget.getTopK(), properties.getDefaultTopK());
+        Integer timeoutMs = valueOrDefault(budget.getTimeoutMs(), properties.getDefaultTimeoutMs());
+        Integer maxCandidates = valueOrDefault(budget.getMaxCandidates(),
+            properties.getDefaultMaxCandidates());
+        final Integer tokenBudget = valueOrDefault(budget.getTokenBudget(),
+            properties.getDefaultTokenBudget());
+        range("topK", topK, properties.getMaxTopK());
+        range("timeoutMs", timeoutMs, properties.getMaxTimeoutMs());
+        range("maxCandidates", maxCandidates, properties.getMaxCandidates());
+        range("tokenBudget", tokenBudget, properties.getMaxTokenBudget());
+        if (topK > maxCandidates) {
+            throw invalid("topK must not exceed maxCandidates");
+        }
+        return new RetrievalBudget(topK, timeoutMs, maxCandidates, tokenBudget);
+    }
+
+    private static RetrievalBudget defaults(RetrievalProperties properties) {
+        return new RetrievalBudget(properties.getDefaultTopK(), properties.getDefaultTimeoutMs(),
+            properties.getDefaultMaxCandidates(), properties.getDefaultTokenBudget());
+    }
+
+    private static int valueOrDefault(Integer value, int defaultValue) {
+        return value == null ? defaultValue : value;
+    }
+
+    private static void range(String name, int value, int max) {
+        if (value < 1 || value > max) {
+            throw invalid(name + " must be between 1 and " + max);
+        }
+    }
+
+    private static RetrievalException invalid(String message) {
+        return new RetrievalException(RetrievalErrorCode.INVALID_REQUEST, message);
+    }
+}

--- a/geaflow-ai/src/main/java/org/apache/geaflow/ai/retrieval/service/RetrievalBudgetValidator.java
+++ b/geaflow-ai/src/main/java/org/apache/geaflow/ai/retrieval/service/RetrievalBudgetValidator.java
@@ -38,6 +38,10 @@ public final class RetrievalBudgetValidator {
             }
             return defaults(properties);
         }
+        if (requireAllValues && (budget.getTopK() == null || budget.getTimeoutMs() == null
+            || budget.getMaxCandidates() == null || budget.getTokenBudget() == null)) {
+            throw invalid("all budget values are required");
+        }
         Integer topK = valueOrDefault(budget.getTopK(), properties.getDefaultTopK());
         Integer timeoutMs = valueOrDefault(budget.getTimeoutMs(), properties.getDefaultTimeoutMs());
         Integer maxCandidates = valueOrDefault(budget.getMaxCandidates(),

--- a/geaflow-ai/src/main/java/org/apache/geaflow/ai/retrieval/service/RetrievalErrorValidator.java
+++ b/geaflow-ai/src/main/java/org/apache/geaflow/ai/retrieval/service/RetrievalErrorValidator.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.geaflow.ai.retrieval.service;
+
+import org.apache.geaflow.ai.retrieval.api.model.RetrievalError;
+import org.apache.geaflow.ai.retrieval.api.model.RetrievalErrorCode;
+import org.apache.geaflow.ai.retrieval.api.model.RetrievalException;
+
+/** Validates stable machine-readable error responses. */
+public final class RetrievalErrorValidator {
+
+    private RetrievalErrorValidator() {
+    }
+
+    public static RetrievalError validate(RetrievalError error) {
+        if (error == null || blank(error.getRequestId()) || error.getCode() == null
+            || blank(error.getMessage())) {
+            throw invalid("requestId, code, and message are required");
+        }
+        if (error.isRetriable() != error.getCode().isRetriable()) {
+            throw invalid("retriable does not match error code");
+        }
+        return error;
+    }
+
+    private static boolean blank(String value) {
+        return value == null || value.trim().isEmpty();
+    }
+
+    private static RetrievalException invalid(String message) {
+        return new RetrievalException(RetrievalErrorCode.INVALID_REQUEST, message);
+    }
+}

--- a/geaflow-ai/src/main/java/org/apache/geaflow/ai/retrieval/service/RetrievalRequestValidator.java
+++ b/geaflow-ai/src/main/java/org/apache/geaflow/ai/retrieval/service/RetrievalRequestValidator.java
@@ -19,6 +19,7 @@
 package org.apache.geaflow.ai.retrieval.service;
 
 import java.util.List;
+import java.util.Objects;
 import org.apache.geaflow.ai.retrieval.api.model.ExecutionMode;
 import org.apache.geaflow.ai.retrieval.api.model.RetrievalBudget;
 import org.apache.geaflow.ai.retrieval.api.model.RetrievalCommand;
@@ -36,7 +37,8 @@ public class RetrievalRequestValidator {
     private final RetrievalProperties properties;
 
     public RetrievalRequestValidator(RetrievalProperties properties) {
-        this.properties = properties;
+        this.properties = Objects.requireNonNull(properties, "properties");
+        this.properties.validateConfiguration();
     }
 
     public RetrievalCommand validate(RetrievalRequest request) {
@@ -55,23 +57,10 @@ public class RetrievalRequestValidator {
         }
 
         RetrievalBudget input = request.getBudget();
-        final int topK = valueOrDefault(input == null ? null : input.getTopK(),
-            properties.getDefaultTopK());
-        final int timeoutMs = valueOrDefault(input == null ? null : input.getTimeoutMs(),
-            properties.getDefaultTimeoutMs());
-        final int maxCandidates = valueOrDefault(input == null ? null : input.getMaxCandidates(),
-            properties.getDefaultMaxCandidates());
-        final int tokenBudget = valueOrDefault(input == null ? null : input.getTokenBudget(),
-            properties.getDefaultTokenBudget());
-        range("topK", topK, properties.getMaxTopK());
-        range("timeoutMs", timeoutMs, properties.getMaxTimeoutMs());
-        range("maxCandidates", maxCandidates, properties.getMaxCandidates());
-        range("tokenBudget", tokenBudget, properties.getMaxTokenBudget());
-        if (topK > maxCandidates) {
-            throw invalid("topK must not exceed maxCandidates");
-        }
+        final RetrievalBudget effectiveBudget = RetrievalBudgetValidator.validate(input,
+            properties, false);
         return new RetrievalCommand(graphName, query, mode, executionMode,
-            new RetrievalBudget(topK, timeoutMs, maxCandidates, tokenBudget));
+            effectiveBudget);
     }
 
     private static String trimmed(String value, String name, int maxLength) {
@@ -104,16 +93,6 @@ public class RetrievalRequestValidator {
             return mode;
         } catch (IllegalArgumentException e) {
             throw unsupported("unsupported execution mode: " + value);
-        }
-    }
-
-    private static int valueOrDefault(Integer value, int defaultValue) {
-        return value == null ? defaultValue : value;
-    }
-
-    private static void range(String name, int value, int max) {
-        if (value < 1 || value > max) {
-            throw invalid(name + " must be between 1 and " + max);
         }
     }
 

--- a/geaflow-ai/src/main/java/org/apache/geaflow/ai/retrieval/service/RetrievalRequestValidator.java
+++ b/geaflow-ai/src/main/java/org/apache/geaflow/ai/retrieval/service/RetrievalRequestValidator.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.geaflow.ai.retrieval.service;
+
+import java.util.List;
+import org.apache.geaflow.ai.retrieval.api.model.ExecutionMode;
+import org.apache.geaflow.ai.retrieval.api.model.RetrievalBudget;
+import org.apache.geaflow.ai.retrieval.api.model.RetrievalCommand;
+import org.apache.geaflow.ai.retrieval.api.model.RetrievalErrorCode;
+import org.apache.geaflow.ai.retrieval.api.model.RetrievalException;
+import org.apache.geaflow.ai.retrieval.api.model.RetrievalMode;
+import org.apache.geaflow.ai.retrieval.api.model.RetrievalRequest;
+import org.apache.geaflow.ai.retrieval.config.RetrievalProperties;
+
+/** Converts an untrusted wire request into a bounded immutable command. */
+public class RetrievalRequestValidator {
+
+    private static final int MAX_GRAPH_NAME_LENGTH = 128;
+    private static final int MAX_QUERY_LENGTH = 4096;
+    private final RetrievalProperties properties;
+
+    public RetrievalRequestValidator(RetrievalProperties properties) {
+        this.properties = properties;
+    }
+
+    public RetrievalCommand validate(RetrievalRequest request) {
+        if (request == null) {
+            throw invalid("request is required");
+        }
+        final String graphName = trimmed(request.getGraphName(), "graphName", MAX_GRAPH_NAME_LENGTH);
+        final String query = trimmed(request.getQuery(), "query", MAX_QUERY_LENGTH);
+        final RetrievalMode mode = parseMode(request.getMode() == null
+            ? properties.getDefaultMode() : request.getMode());
+        final ExecutionMode executionMode = parseExecutionMode(request.getExecutionMode() == null
+            ? properties.getDefaultExecutionMode() : request.getExecutionMode());
+        List<Double> vector = request.getQueryVector();
+        if (vector != null && !vector.isEmpty()) {
+            throw unsupported("non-empty queryVector is not supported in v1");
+        }
+
+        RetrievalBudget input = request.getBudget();
+        final int topK = valueOrDefault(input == null ? null : input.getTopK(),
+            properties.getDefaultTopK());
+        final int timeoutMs = valueOrDefault(input == null ? null : input.getTimeoutMs(),
+            properties.getDefaultTimeoutMs());
+        final int maxCandidates = valueOrDefault(input == null ? null : input.getMaxCandidates(),
+            properties.getDefaultMaxCandidates());
+        final int tokenBudget = valueOrDefault(input == null ? null : input.getTokenBudget(),
+            properties.getDefaultTokenBudget());
+        range("topK", topK, properties.getMaxTopK());
+        range("timeoutMs", timeoutMs, properties.getMaxTimeoutMs());
+        range("maxCandidates", maxCandidates, properties.getMaxCandidates());
+        range("tokenBudget", tokenBudget, properties.getMaxTokenBudget());
+        if (topK > maxCandidates) {
+            throw invalid("topK must not exceed maxCandidates");
+        }
+        return new RetrievalCommand(graphName, query, mode, executionMode,
+            new RetrievalBudget(topK, timeoutMs, maxCandidates, tokenBudget));
+    }
+
+    private static String trimmed(String value, String name, int maxLength) {
+        if (value == null || value.trim().isEmpty()) {
+            throw invalid(name + " is required");
+        }
+        String result = value.trim();
+        if (result.length() > maxLength) {
+            throw invalid(name + " exceeds maximum length " + maxLength);
+        }
+        return result;
+    }
+
+    private static RetrievalMode parseMode(String value) {
+        if (value == null || !RetrievalMode.KEYWORD.name().equals(value)) {
+            throw unsupported("unsupported retrieval mode: " + value);
+        }
+        return RetrievalMode.KEYWORD;
+    }
+
+    private static ExecutionMode parseExecutionMode(String value) {
+        if (value == null) {
+            throw unsupported("unsupported execution mode: null");
+        }
+        try {
+            ExecutionMode mode = ExecutionMode.valueOf(value);
+            if (mode != ExecutionMode.SEQUENTIAL) {
+                throw unsupported("unsupported execution mode: " + value);
+            }
+            return mode;
+        } catch (IllegalArgumentException e) {
+            throw unsupported("unsupported execution mode: " + value);
+        }
+    }
+
+    private static int valueOrDefault(Integer value, int defaultValue) {
+        return value == null ? defaultValue : value;
+    }
+
+    private static void range(String name, int value, int max) {
+        if (value < 1 || value > max) {
+            throw invalid(name + " must be between 1 and " + max);
+        }
+    }
+
+    private static RetrievalException invalid(String message) {
+        return new RetrievalException(RetrievalErrorCode.INVALID_REQUEST, message);
+    }
+
+    private static RetrievalException unsupported(String message) {
+        return new RetrievalException(RetrievalErrorCode.UNSUPPORTED_OPTION, message);
+    }
+}

--- a/geaflow-ai/src/main/java/org/apache/geaflow/ai/retrieval/service/RetrievalResponseValidator.java
+++ b/geaflow-ai/src/main/java/org/apache/geaflow/ai/retrieval/service/RetrievalResponseValidator.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.geaflow.ai.retrieval.service;
+
+import java.util.Collections;
+import java.util.List;
+import org.apache.geaflow.ai.retrieval.api.model.ExecutionMode;
+import org.apache.geaflow.ai.retrieval.api.model.RetrievalBudget;
+import org.apache.geaflow.ai.retrieval.api.model.RetrievalErrorCode;
+import org.apache.geaflow.ai.retrieval.api.model.RetrievalException;
+import org.apache.geaflow.ai.retrieval.api.model.RetrievalMode;
+import org.apache.geaflow.ai.retrieval.api.model.RetrievalResponse;
+import org.apache.geaflow.ai.retrieval.api.model.RetrievalTrace;
+import org.apache.geaflow.ai.retrieval.api.model.TraceStage;
+import org.apache.geaflow.ai.retrieval.config.RetrievalProperties;
+
+/** Validates the complete success response before it crosses the API boundary. */
+public final class RetrievalResponseValidator {
+
+    private RetrievalResponseValidator() {
+    }
+
+    public static RetrievalResponse validate(RetrievalResponse response,
+                                              RetrievalProperties properties) {
+        if (response == null) {
+            throw invalid("response is required");
+        }
+        required(response.getRequestId(), "requestId");
+        required(response.getGraphName(), "graphName");
+        required(response.getGraphVersion(), "graphVersion");
+        RetrievalTrace trace = response.getTrace();
+        if (trace == null) {
+            throw invalid("trace is required");
+        }
+        required(trace.getTraceVersion(), "traceVersion");
+        required(trace.getOriginalQuery(), "originalQuery");
+        if (trace.getSelectedMode() != RetrievalMode.KEYWORD) {
+            throw unsupported("unsupported retrieval mode in trace");
+        }
+        if (trace.getExecutionMode() != ExecutionMode.SEQUENTIAL) {
+            throw unsupported("unsupported execution mode in trace");
+        }
+        List<TraceStage> stages = trace.getStages();
+        if (stages == null) {
+            throw invalid("stages is required");
+        }
+        for (TraceStage stage : stages) {
+            if (stage == null) {
+                throw invalid("stages must not contain null");
+            }
+            required(stage.getName(), "stage.name");
+            required(stage.getStatus(), "stage.status");
+        }
+        if (response.getEvidence() == null || response.getPaths() == null
+            || response.getSources() == null || response.getDegradedChannels() == null) {
+            throw invalid("response collections are required");
+        }
+        RetrievalBudget effectiveBudget = response.getEffectiveBudget();
+        RetrievalBudgetValidator.validate(effectiveBudget, properties, true);
+        return response;
+    }
+
+    public static RetrievalResponse normalizeCollections(RetrievalResponse response) {
+        response.setEvidence(response.getEvidence() == null
+            ? Collections.emptyList() : response.getEvidence());
+        response.setPaths(response.getPaths() == null
+            ? Collections.emptyList() : response.getPaths());
+        response.setSources(response.getSources() == null
+            ? Collections.emptyList() : response.getSources());
+        response.setDegradedChannels(response.getDegradedChannels() == null
+            ? Collections.emptyList() : response.getDegradedChannels());
+        return response;
+    }
+
+    private static void required(String value, String name) {
+        if (value == null || value.trim().isEmpty()) {
+            throw invalid(name + " is required");
+        }
+    }
+
+    private static RetrievalException invalid(String message) {
+        return new RetrievalException(RetrievalErrorCode.INVALID_REQUEST, message);
+    }
+
+    private static RetrievalException unsupported(String message) {
+        return new RetrievalException(RetrievalErrorCode.UNSUPPORTED_OPTION, message);
+    }
+}

--- a/geaflow-ai/src/main/java/org/apache/geaflow/ai/retrieval/service/RetrievalResponseValidator.java
+++ b/geaflow-ai/src/main/java/org/apache/geaflow/ai/retrieval/service/RetrievalResponseValidator.java
@@ -51,8 +51,14 @@ public final class RetrievalResponseValidator {
         }
         required(trace.getTraceVersion(), "traceVersion");
         required(trace.getOriginalQuery(), "originalQuery");
+        if (trace.getSelectedMode() == null) {
+            throw invalid("selectedMode is required");
+        }
         if (trace.getSelectedMode() != RetrievalMode.KEYWORD) {
             throw unsupported("unsupported retrieval mode in trace");
+        }
+        if (trace.getExecutionMode() == null) {
+            throw invalid("executionMode is required");
         }
         if (trace.getExecutionMode() != ExecutionMode.SEQUENTIAL) {
             throw unsupported("unsupported execution mode in trace");
@@ -69,8 +75,10 @@ public final class RetrievalResponseValidator {
             required(stage.getStatus(), "stage.status");
         }
         if (response.getEvidence() == null || response.getPaths() == null
-            || response.getSources() == null || response.getDegradedChannels() == null) {
-            throw invalid("response collections are required");
+            || response.getSources() == null || response.getDegradedChannels() == null
+            || response.getEvidence().contains(null) || response.getPaths().contains(null)
+            || response.getSources().contains(null) || response.getDegradedChannels().contains(null)) {
+            throw invalid("response collections are required and must not contain null");
         }
         RetrievalBudget effectiveBudget = response.getEffectiveBudget();
         RetrievalBudgetValidator.validate(effectiveBudget, properties, true);

--- a/geaflow-ai/src/main/resources/application.yml
+++ b/geaflow-ai/src/main/resources/application.yml
@@ -28,3 +28,17 @@ logging:
   level:
     root: INFO
     org.apache.geaflow.ai: DEBUG
+
+retrieval:
+  config-version: v1
+  ready-graph-name: Confucius
+  default-mode: KEYWORD
+  default-execution-mode: SEQUENTIAL
+  default-top-k: 10
+  max-top-k: 100
+  default-timeout-ms: 3000
+  max-timeout-ms: 10000
+  default-max-candidates: 100
+  max-candidates: 1000
+  default-token-budget: 4096
+  max-token-budget: 16384

--- a/geaflow-ai/src/test/java/org/apache/geaflow/ai/retrieval/api/RetrievalApiJsonTest.java
+++ b/geaflow-ai/src/test/java/org/apache/geaflow/ai/retrieval/api/RetrievalApiJsonTest.java
@@ -19,6 +19,7 @@
 package org.apache.geaflow.ai.retrieval.api;
 
 import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
 import com.google.gson.JsonParser;
 import java.io.IOException;
 import java.io.InputStream;
@@ -32,14 +33,18 @@ import org.apache.geaflow.ai.retrieval.api.model.ExecutionMode;
 import org.apache.geaflow.ai.retrieval.api.model.RetrievalBudget;
 import org.apache.geaflow.ai.retrieval.api.model.RetrievalError;
 import org.apache.geaflow.ai.retrieval.api.model.RetrievalErrorCode;
+import org.apache.geaflow.ai.retrieval.api.model.RetrievalException;
+import org.apache.geaflow.ai.retrieval.api.model.RetrievalMode;
 import org.apache.geaflow.ai.retrieval.api.model.RetrievalRequest;
 import org.apache.geaflow.ai.retrieval.api.model.RetrievalResponse;
 import org.apache.geaflow.ai.retrieval.api.model.RetrievalTrace;
-import org.apache.geaflow.ai.retrieval.api.model.RetrievalMode;
 import org.apache.geaflow.ai.retrieval.api.model.TraceStage;
 import org.apache.geaflow.ai.retrieval.codec.RetrievalApiJson;
+import org.apache.geaflow.ai.retrieval.config.RetrievalProperties;
+import org.apache.geaflow.ai.retrieval.model.document.SourceRef;
 import org.apache.geaflow.ai.retrieval.model.evidence.Evidence;
 import org.apache.geaflow.ai.retrieval.model.evidence.EvidenceKind;
+import org.apache.geaflow.ai.retrieval.model.graph.GraphPathRef;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -109,6 +114,75 @@ public class RetrievalApiJsonTest {
         unicodeOversized.append("\"}");
         Assertions.assertThrows(RuntimeException.class,
             () -> RetrievalApiJson.parseRequest(unicodeOversized.toString()));
+    }
+
+    @Test
+    public void appliesSemanticValidationAtRequestJsonBoundary() {
+        Assertions.assertThrows(RetrievalException.class, () -> RetrievalApiJson.parseRequest(
+            "{\"graphName\":\"g\",\"query\":\"q\",\"mode\":\"HYBRID\"}"));
+        Assertions.assertThrows(RetrievalException.class, () -> RetrievalApiJson.parseRequest(
+            "{\"graphName\":\"g\",\"query\":\"q\","
+                + "\"executionMode\":\"PARALLEL\"}"));
+        Assertions.assertThrows(RetrievalException.class, () -> RetrievalApiJson.parseRequest(
+            "{\"graphName\":\"g\",\"query\":\"q\","
+                + "\"budget\":{\"topK\":0}}"));
+
+        StringBuilder longQuery = new StringBuilder("{\"graphName\":\"g\",\"query\":\"");
+        for (int i = 0; i < 4097; i++) {
+            longQuery.append('q');
+        }
+        longQuery.append("\"}");
+        Assertions.assertThrows(RetrievalException.class,
+            () -> RetrievalApiJson.parseRequest(longQuery.toString()));
+
+        RetrievalProperties properties = new RetrievalProperties();
+        properties.setMaxTopK(5);
+        properties.setDefaultTopK(5);
+        properties.validateConfiguration();
+        Assertions.assertThrows(RetrievalException.class, () -> RetrievalApiJson.parseRequest(
+            "{\"graphName\":\"g\",\"query\":\"q\","
+                + "\"budget\":{\"topK\":6}}", properties));
+    }
+
+    @Test
+    public void rejectsSemanticallyInvalidRequestSerialization() {
+        RetrievalRequest request = new RetrievalRequest();
+        request.setGraphName("graph");
+        request.setQuery("query");
+        request.setMode("HYBRID");
+
+        Assertions.assertThrows(RetrievalException.class, () -> RetrievalApiJson.toJson(request));
+    }
+
+    @Test
+    public void rejectsExcessiveJsonNestingBeforeParsing() {
+        StringBuilder json = new StringBuilder("{\"graphName\":\"g\",\"query\":\"q\",\"nested\":");
+        for (int i = 0; i < 257; i++) {
+            json.append('[');
+        }
+        json.append('0');
+        for (int i = 0; i < 257; i++) {
+            json.append(']');
+        }
+        json.append('}');
+
+        Assertions.assertThrows(JsonParseException.class,
+            () -> RetrievalApiJson.parseRequest(json.toString()));
+    }
+
+    @Test
+    public void parsesOnlyExactIntegerBudgetNumbers() {
+        Assertions.assertThrows(JsonParseException.class, () -> RetrievalApiJson.parseRequest(
+            "{\"graphName\":\"g\",\"query\":\"q\","
+                + "\"budget\":{\"topK\":1.0000000000000001}}"));
+        Assertions.assertThrows(JsonParseException.class, () -> RetrievalApiJson.parseRequest(
+            "{\"graphName\":\"g\",\"query\":\"q\","
+                + "\"budget\":{\"topK\":2147483648}}"));
+
+        RetrievalRequest request = RetrievalApiJson.parseRequest(
+            "{\"graphName\":\"g\",\"query\":\"q\","
+                + "\"budget\":{\"topK\":1e1}}");
+        Assertions.assertEquals(Integer.valueOf(10), request.getBudget().getTopK());
     }
 
     @Test
@@ -209,6 +283,48 @@ public class RetrievalApiJsonTest {
     }
 
     @Test
+    public void rejectsPartialEffectiveBudgetSerialization() {
+        RetrievalResponse response = validResponse();
+        response.setEffectiveBudget(new RetrievalBudget(null, 3000, 100, 4096));
+
+        Assertions.assertThrows(RetrievalException.class, () -> RetrievalApiJson.toJson(response));
+    }
+
+    @Test
+    public void rejectsNullResponseCollectionElements() {
+        RetrievalResponse evidence = validResponse();
+        evidence.setEvidence(Collections.<Evidence>singletonList(null));
+        Assertions.assertThrows(RetrievalException.class, () -> RetrievalApiJson.toJson(evidence));
+
+        RetrievalResponse paths = validResponse();
+        paths.setPaths(Collections.<GraphPathRef>singletonList(null));
+        Assertions.assertThrows(RetrievalException.class, () -> RetrievalApiJson.toJson(paths));
+
+        RetrievalResponse sources = validResponse();
+        sources.setSources(Collections.<SourceRef>singletonList(null));
+        Assertions.assertThrows(RetrievalException.class, () -> RetrievalApiJson.toJson(sources));
+
+        RetrievalResponse channels = validResponse();
+        channels.setDegradedChannels(Collections.<String>singletonList(null));
+        Assertions.assertThrows(RetrievalException.class, () -> RetrievalApiJson.toJson(channels));
+    }
+
+    @Test
+    public void reportsMissingTraceModesAsInvalidRequest() {
+        RetrievalResponse missingMode = validResponse();
+        missingMode.getTrace().setSelectedMode(null);
+        RetrievalException modeException = Assertions.assertThrows(RetrievalException.class,
+            () -> RetrievalApiJson.toJson(missingMode));
+        Assertions.assertEquals(RetrievalErrorCode.INVALID_REQUEST, modeException.getCode());
+
+        RetrievalResponse missingExecutionMode = validResponse();
+        missingExecutionMode.getTrace().setExecutionMode(null);
+        RetrievalException executionException = Assertions.assertThrows(RetrievalException.class,
+            () -> RetrievalApiJson.toJson(missingExecutionMode));
+        Assertions.assertEquals(RetrievalErrorCode.INVALID_REQUEST, executionException.getCode());
+    }
+
+    @Test
     public void errorCodeAndRetriableFlagAreStable() {
         RetrievalError error = new RetrievalError("req-3", RetrievalErrorCode.INDEX_NOT_READY,
             "not ready");
@@ -257,6 +373,25 @@ public class RetrievalApiJsonTest {
         Assertions.assertTrue(json.has("budget"));
         Assertions.assertTrue(json.getAsJsonObject("budget").has("maxCandidates"));
         Assertions.assertFalse(json.has("graph_name"));
+    }
+
+    private static RetrievalResponse validResponse() {
+        RetrievalResponse response = new RetrievalResponse();
+        response.setRequestId("req-1");
+        response.setGraphName("graph");
+        response.setGraphVersion("v1");
+        response.setEvidence(Collections.singletonList(new Evidence("e-1", EvidenceKind.CHUNK,
+            "text", null, null, null, null, null, null, 1)));
+        RetrievalTrace trace = new RetrievalTrace();
+        trace.setTraceVersion("v1");
+        trace.setOriginalQuery("confucius");
+        trace.setSelectedMode(RetrievalMode.KEYWORD);
+        trace.setExecutionMode(ExecutionMode.SEQUENTIAL);
+        trace.setStages(Collections.singletonList(new TraceStage("keyword", "COMPLETED", null)));
+        trace.setStopReason("COMPLETED");
+        response.setTrace(trace);
+        response.setEffectiveBudget(new RetrievalBudget(10, 3000, 100, 4096));
+        return response;
     }
 
     private static String read(String resource) throws IOException {

--- a/geaflow-ai/src/test/java/org/apache/geaflow/ai/retrieval/api/RetrievalApiJsonTest.java
+++ b/geaflow-ai/src/test/java/org/apache/geaflow/ai/retrieval/api/RetrievalApiJsonTest.java
@@ -181,6 +181,34 @@ public class RetrievalApiJsonTest {
     }
 
     @Test
+    public void rejectsUnsupportedTraceModesAndUnboundedEffectiveBudget() {
+        String parallel = responseJson("PARALLEL", "SEQUENTIAL", 10, 3000, 100, 4096);
+        Assertions.assertThrows(RuntimeException.class,
+            () -> RetrievalApiJson.parseResponse(parallel));
+
+        String overLimit = responseJson("KEYWORD", "SEQUENTIAL", 101, 3000, 100, 4096);
+        Assertions.assertThrows(RuntimeException.class,
+            () -> RetrievalApiJson.parseResponse(overLimit));
+    }
+
+    @Test
+    public void rejectsBlankRequiredResponseAndErrorFields() {
+        String blankGraph = responseJson("KEYWORD", "SEQUENTIAL", 10, 3000, 100, 4096)
+            .replace("\"graphName\":\"graph\"", "\"graphName\":\" \"");
+        Assertions.assertThrows(RuntimeException.class,
+            () -> RetrievalApiJson.parseResponse(blankGraph));
+        Assertions.assertThrows(RuntimeException.class, () -> RetrievalApiJson.parseError(
+            "{\"requestId\":\" \",\"code\":\"INTERNAL_ERROR\","
+                + "\"message\":\"x\",\"retriable\":false}"));
+    }
+
+    @Test
+    public void rejectsIncompleteResponseSerialization() {
+        RetrievalResponse response = new RetrievalResponse();
+        Assertions.assertThrows(RuntimeException.class, () -> RetrievalApiJson.toJson(response));
+    }
+
+    @Test
     public void errorCodeAndRetriableFlagAreStable() {
         RetrievalError error = new RetrievalError("req-3", RetrievalErrorCode.INDEX_NOT_READY,
             "not ready");
@@ -244,5 +272,18 @@ public class RetrievalApiJsonTest {
             }
             return result.toString();
         }
+    }
+
+    private static String responseJson(String mode, String executionMode, int topK,
+                                       int timeoutMs, int maxCandidates, int tokenBudget) {
+        return "{\"requestId\":\"r\",\"graphName\":\"graph\","
+            + "\"graphVersion\":\"v1\",\"evidence\":[],\"paths\":[],"
+            + "\"sources\":[],\"degradedChannels\":[],\"trace\":{"
+            + "\"traceVersion\":\"v1\",\"originalQuery\":\"q\","
+            + "\"selectedMode\":\"" + mode + "\",\"executionMode\":\""
+            + executionMode + "\",\"stages\":[]},\"effectiveBudget\":{"
+            + "\"topK\":" + topK + ",\"timeoutMs\":" + timeoutMs
+            + ",\"maxCandidates\":" + maxCandidates + ",\"tokenBudget\":"
+            + tokenBudget + "}}";
     }
 }

--- a/geaflow-ai/src/test/java/org/apache/geaflow/ai/retrieval/api/RetrievalApiJsonTest.java
+++ b/geaflow-ai/src/test/java/org/apache/geaflow/ai/retrieval/api/RetrievalApiJsonTest.java
@@ -1,0 +1,248 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.geaflow.ai.retrieval.api;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.geaflow.ai.retrieval.api.model.ExecutionMode;
+import org.apache.geaflow.ai.retrieval.api.model.RetrievalBudget;
+import org.apache.geaflow.ai.retrieval.api.model.RetrievalError;
+import org.apache.geaflow.ai.retrieval.api.model.RetrievalErrorCode;
+import org.apache.geaflow.ai.retrieval.api.model.RetrievalRequest;
+import org.apache.geaflow.ai.retrieval.api.model.RetrievalResponse;
+import org.apache.geaflow.ai.retrieval.api.model.RetrievalTrace;
+import org.apache.geaflow.ai.retrieval.api.model.RetrievalMode;
+import org.apache.geaflow.ai.retrieval.api.model.TraceStage;
+import org.apache.geaflow.ai.retrieval.codec.RetrievalApiJson;
+import org.apache.geaflow.ai.retrieval.model.evidence.Evidence;
+import org.apache.geaflow.ai.retrieval.model.evidence.EvidenceKind;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/** JSON contract tests independent of Solon and HTTP. */
+public class RetrievalApiJsonTest {
+
+    @Test
+    public void parsesMinimalAndFullRequests() {
+        RetrievalRequest minimal = RetrievalApiJson.parseRequest(
+            "{\"graphName\":\"graph\",\"query\":\"confucius\"}");
+        Assertions.assertEquals("graph", minimal.getGraphName());
+        Assertions.assertNull(minimal.getBudget());
+
+        RetrievalRequest full = RetrievalApiJson.parseRequest(
+            "{\"graphName\":\"graph\",\"query\":\"confucius\","
+                + "\"queryVector\":[],\"mode\":\"KEYWORD\","
+                + "\"executionMode\":\"SEQUENTIAL\","
+                + "\"budget\":{\"topK\":10,\"timeoutMs\":3000,"
+                + "\"maxCandidates\":100,\"tokenBudget\":4096},"
+                + "\"futureField\":true}");
+        Assertions.assertEquals("KEYWORD", full.getMode());
+        Assertions.assertEquals(Integer.valueOf(100), full.getBudget().getMaxCandidates());
+        Assertions.assertEquals(Collections.emptyList(), full.getQueryVector());
+    }
+
+    @Test
+    public void checkedInExamplesAreValidContractDocuments() throws IOException {
+        RetrievalRequest request = RetrievalApiJson.parseRequest(read("retrieval/api/request-full.json"));
+        RetrievalResponse response = RetrievalApiJson.parseResponse(
+            read("retrieval/api/response-empty.json"));
+        RetrievalError error = RetrievalApiJson.parseError(read("retrieval/api/error-index-not-ready.json"));
+
+        Assertions.assertEquals("week1-keyword-graph", request.getGraphName());
+        Assertions.assertTrue(response.getEvidence().isEmpty());
+        Assertions.assertEquals(RetrievalErrorCode.INDEX_NOT_READY, error.getCode());
+    }
+
+    @Test
+    public void rejectsWrongTypesMalformedJsonAndDuplicateFields() {
+        Assertions.assertThrows(RuntimeException.class,
+            () -> RetrievalApiJson.parseRequest("{\"graphName\":1,\"query\":\"x\"}"));
+        Assertions.assertThrows(RuntimeException.class,
+            () -> RetrievalApiJson.parseRequest("{\"graphName\":\"g\",\"query\":\"x\","
+                + "\"budget\":{\"topK\":1.5}}"));
+        Assertions.assertThrows(RuntimeException.class,
+            () -> RetrievalApiJson.parseRequest("{\"graphName\":\"g\",\"query\":\"x\","
+                + "\"budget\":1}"));
+        Assertions.assertThrows(RuntimeException.class,
+            () -> RetrievalApiJson.parseRequest("{\"graphName\":\"g\",\"query\":\"x\","
+                + "\"queryVector\":[null]}"));
+        Assertions.assertThrows(RuntimeException.class,
+            () -> RetrievalApiJson.parseRequest("{\"graphName\":\"g\",\"query\":\"x\"} trailing"));
+        Assertions.assertThrows(RuntimeException.class,
+            () -> RetrievalApiJson.parseRequest("{\"graphName\":\"g\",\"graphName\":\"x\","
+                + "\"query\":\"q\"}"));
+        StringBuilder oversized = new StringBuilder("{\"graphName\":\"g\",\"query\":\"");
+        for (int i = 0; i < 1024 * 1024; i++) {
+            oversized.append('x');
+        }
+        oversized.append("\"}");
+        Assertions.assertThrows(RuntimeException.class,
+            () -> RetrievalApiJson.parseRequest(oversized.toString()));
+        StringBuilder unicodeOversized = new StringBuilder("{\"graphName\":\"g\",\"query\":\"");
+        for (int i = 0; i < 350 * 1024; i++) {
+            unicodeOversized.append('\u4e2d');
+        }
+        unicodeOversized.append("\"}");
+        Assertions.assertThrows(RuntimeException.class,
+            () -> RetrievalApiJson.parseRequest(unicodeOversized.toString()));
+    }
+
+    @Test
+    public void responseKeepsRequiredCollectionsAndRoundTrips() {
+        RetrievalResponse response = new RetrievalResponse();
+        response.setRequestId("req-1");
+        response.setGraphName("graph");
+        response.setGraphVersion("v1");
+        response.setEvidence(Collections.singletonList(new Evidence("e-1", EvidenceKind.CHUNK,
+            "text", null, null, null, null, null, null, 1)));
+        RetrievalTrace trace = new RetrievalTrace();
+        trace.setTraceVersion("v1");
+        trace.setOriginalQuery("confucius");
+        trace.setSelectedMode(RetrievalMode.KEYWORD);
+        trace.setExecutionMode(ExecutionMode.SEQUENTIAL);
+        trace.setStages(Collections.singletonList(new TraceStage("keyword", "COMPLETED", null)));
+        trace.setStopReason("COMPLETED");
+        response.setTrace(trace);
+        response.setEffectiveBudget(new RetrievalBudget(10, 3000, 100, 4096));
+
+        String json = RetrievalApiJson.toJson(response);
+        RetrievalResponse restored = RetrievalApiJson.parseResponse(json);
+
+        Assertions.assertEquals("req-1", restored.getRequestId());
+        Assertions.assertEquals(1, restored.getEvidence().size());
+        Assertions.assertNotNull(restored.getPaths());
+        Assertions.assertNotNull(restored.getSources());
+        Assertions.assertNotNull(restored.getDegradedChannels());
+        Assertions.assertEquals("v1", restored.getTrace().getTraceVersion());
+        Assertions.assertEquals(Integer.valueOf(4096),
+            restored.getEffectiveBudget().getTokenBudget());
+    }
+
+    @Test
+    public void emptyResponseUsesArraysInsteadOfNullCollections() {
+        String json = "{\"requestId\":\"req-2\",\"graphName\":\"graph\","
+            + "\"graphVersion\":\"v1\",\"evidence\":[],\"paths\":[],"
+            + "\"sources\":[],\"degradedChannels\":[],"
+            + "\"trace\":{\"traceVersion\":\"v1\","
+            + "\"originalQuery\":\"none\",\"selectedMode\":\"KEYWORD\","
+            + "\"executionMode\":\"SEQUENTIAL\",\"stages\":[]},"
+            + "\"effectiveBudget\":{\"topK\":10,\"timeoutMs\":3000,"
+            + "\"maxCandidates\":100,\"tokenBudget\":4096}}";
+        RetrievalResponse response = RetrievalApiJson.parseResponse(json);
+
+        Assertions.assertNotNull(response.getEvidence());
+        Assertions.assertNotNull(response.getPaths());
+        Assertions.assertNotNull(response.getSources());
+        Assertions.assertNotNull(response.getDegradedChannels());
+        Assertions.assertTrue(response.getEvidence().isEmpty());
+    }
+
+    @Test
+    public void rejectsResponseMissingRequiredSections() {
+        Assertions.assertThrows(RuntimeException.class, () -> RetrievalApiJson.parseResponse(
+            "{\"requestId\":\"r\",\"graphName\":\"g\",\"graphVersion\":\"v1\"}"));
+    }
+
+    @Test
+    public void rejectsResponseTraceWithoutStages() {
+        String json = "{\"requestId\":\"r\",\"graphName\":\"g\","
+            + "\"graphVersion\":\"v1\",\"evidence\":[],\"paths\":[],"
+            + "\"sources\":[],\"degradedChannels\":[],"
+            + "\"trace\":{\"traceVersion\":\"v1\","
+            + "\"originalQuery\":\"q\",\"selectedMode\":\"KEYWORD\","
+            + "\"executionMode\":\"SEQUENTIAL\"},"
+            + "\"effectiveBudget\":{\"topK\":1,\"timeoutMs\":1,"
+            + "\"maxCandidates\":1,\"tokenBudget\":1}}";
+        Assertions.assertThrows(RuntimeException.class, () -> RetrievalApiJson.parseResponse(json));
+    }
+
+    @Test
+    public void errorCodeAndRetriableFlagAreStable() {
+        RetrievalError error = new RetrievalError("req-3", RetrievalErrorCode.INDEX_NOT_READY,
+            "not ready");
+        RetrievalError restored = RetrievalApiJson.parseError(RetrievalApiJson.toJson(error));
+
+        Assertions.assertEquals(RetrievalErrorCode.INDEX_NOT_READY, restored.getCode());
+        Assertions.assertTrue(restored.isRetriable());
+        Assertions.assertEquals(503, restored.getCode().getHttpStatus());
+        Assertions.assertThrows(RuntimeException.class, () -> RetrievalApiJson.parseError(
+            "{\"requestId\":\"r\",\"code\":\"INDEX_NOT_READY\","
+                + "\"message\":\"x\",\"retriable\":false}"));
+    }
+
+    @Test
+    public void documentsEveryErrorCodeMapping() {
+        Map<RetrievalErrorCode, Integer> statuses = new HashMap<>();
+        statuses.put(RetrievalErrorCode.INVALID_REQUEST, 400);
+        statuses.put(RetrievalErrorCode.UNSUPPORTED_OPTION, 400);
+        statuses.put(RetrievalErrorCode.GRAPH_NOT_FOUND, 404);
+        statuses.put(RetrievalErrorCode.INDEX_NOT_READY, 503);
+        statuses.put(RetrievalErrorCode.RETRIEVAL_TIMEOUT, 504);
+        statuses.put(RetrievalErrorCode.INTERNAL_ERROR, 500);
+
+        Assertions.assertEquals(RetrievalErrorCode.values().length, statuses.size());
+        for (Map.Entry<RetrievalErrorCode, Integer> entry : statuses.entrySet()) {
+            RetrievalErrorCode code = entry.getKey();
+            Assertions.assertEquals(entry.getValue().intValue(), code.getHttpStatus());
+            Assertions.assertEquals(code == RetrievalErrorCode.INDEX_NOT_READY
+                || code == RetrievalErrorCode.RETRIEVAL_TIMEOUT, code.isRetriable());
+            RetrievalError parsed = RetrievalApiJson.parseError(RetrievalApiJson.toJson(
+                new RetrievalError("request", code, "message")));
+            Assertions.assertEquals(code, parsed.getCode());
+        }
+    }
+
+    @Test
+    public void outputUsesDocumentedCamelCaseNames() {
+        RetrievalRequest request = new RetrievalRequest();
+        request.setGraphName("graph");
+        request.setQuery("q");
+        request.setBudget(new RetrievalBudget(1, 2, 3, 4));
+        JsonObject json = new JsonParser().parse(RetrievalApiJson.toJson(request)).getAsJsonObject();
+
+        Assertions.assertTrue(json.has("graphName"));
+        Assertions.assertTrue(json.has("query"));
+        Assertions.assertTrue(json.has("budget"));
+        Assertions.assertTrue(json.getAsJsonObject("budget").has("maxCandidates"));
+        Assertions.assertFalse(json.has("graph_name"));
+    }
+
+    private static String read(String resource) throws IOException {
+        InputStream stream = RetrievalApiJsonTest.class.getClassLoader()
+            .getResourceAsStream(resource);
+        Assertions.assertNotNull(stream);
+        try (Reader reader = new InputStreamReader(stream, StandardCharsets.UTF_8)) {
+            StringBuilder result = new StringBuilder();
+            char[] buffer = new char[1024];
+            int count;
+            while ((count = reader.read(buffer)) >= 0) {
+                result.append(buffer, 0, count);
+            }
+            return result.toString();
+        }
+    }
+}

--- a/geaflow-ai/src/test/java/org/apache/geaflow/ai/retrieval/api/RetrievalPropertiesTest.java
+++ b/geaflow-ai/src/test/java/org/apache/geaflow/ai/retrieval/api/RetrievalPropertiesTest.java
@@ -83,6 +83,10 @@ public class RetrievalPropertiesTest {
         properties = new RetrievalProperties();
         properties.setMaxTopK(0);
         assertInvalid(properties);
+
+        properties = new RetrievalProperties();
+        properties.setConfigVersion("v2");
+        assertInvalid(properties);
     }
 
     private static void assertInvalid(RetrievalProperties properties) {

--- a/geaflow-ai/src/test/java/org/apache/geaflow/ai/retrieval/api/RetrievalPropertiesTest.java
+++ b/geaflow-ai/src/test/java/org/apache/geaflow/ai/retrieval/api/RetrievalPropertiesTest.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.geaflow.ai.retrieval.api;
+
+import org.apache.geaflow.ai.retrieval.api.model.RetrievalErrorCode;
+import org.apache.geaflow.ai.retrieval.api.model.RetrievalException;
+import org.apache.geaflow.ai.retrieval.config.RetrievalProperties;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/** Configuration defaults and hard-limit tests. */
+public class RetrievalPropertiesTest {
+
+    @Test
+    public void validatesVersionedDefaults() {
+        RetrievalProperties properties = new RetrievalProperties();
+        properties.validateConfiguration();
+
+        Assertions.assertEquals("v1", properties.getConfigVersion());
+        Assertions.assertEquals("Confucius", properties.getReadyGraphName());
+        Assertions.assertEquals("KEYWORD", properties.getDefaultMode());
+        Assertions.assertEquals("SEQUENTIAL", properties.getDefaultExecutionMode());
+        Assertions.assertEquals(10, properties.getDefaultTopK());
+        Assertions.assertEquals(100, properties.getMaxTopK());
+        Assertions.assertEquals(3000, properties.getDefaultTimeoutMs());
+        Assertions.assertEquals(10000, properties.getMaxTimeoutMs());
+        Assertions.assertEquals(100, properties.getDefaultMaxCandidates());
+        Assertions.assertEquals(1000, properties.getMaxCandidates());
+        Assertions.assertEquals(4096, properties.getDefaultTokenBudget());
+        Assertions.assertEquals(16384, properties.getMaxTokenBudget());
+    }
+
+    @Test
+    public void rejectsInvalidModesAndLimits() {
+        RetrievalProperties properties = new RetrievalProperties();
+        properties.setDefaultMode("HYBRID");
+        assertInvalid(properties);
+
+        properties = new RetrievalProperties();
+        properties.setDefaultExecutionMode("PARALLEL");
+        assertInvalid(properties);
+
+        properties = new RetrievalProperties();
+        properties.setDefaultTimeoutMs(10001);
+        assertInvalid(properties);
+
+        properties = new RetrievalProperties();
+        properties.setDefaultTokenBudget(16385);
+        assertInvalid(properties);
+    }
+
+    @Test
+    public void rejectsBlankIdentityAndInvertedDefaults() {
+        RetrievalProperties properties = new RetrievalProperties();
+        properties.setConfigVersion(" ");
+        assertInvalid(properties);
+
+        properties = new RetrievalProperties();
+        properties.setReadyGraphName(null);
+        assertInvalid(properties);
+
+        properties = new RetrievalProperties();
+        properties.setDefaultTopK(10);
+        properties.setDefaultMaxCandidates(9);
+        assertInvalid(properties);
+
+        properties = new RetrievalProperties();
+        properties.setMaxTopK(0);
+        assertInvalid(properties);
+    }
+
+    private static void assertInvalid(RetrievalProperties properties) {
+        RetrievalException exception = Assertions.assertThrows(RetrievalException.class,
+            properties::validateConfiguration);
+        Assertions.assertEquals(RetrievalErrorCode.INVALID_REQUEST, exception.getCode());
+    }
+}

--- a/geaflow-ai/src/test/java/org/apache/geaflow/ai/retrieval/api/RetrievalRequestValidatorTest.java
+++ b/geaflow-ai/src/test/java/org/apache/geaflow/ai/retrieval/api/RetrievalRequestValidatorTest.java
@@ -1,0 +1,192 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.geaflow.ai.retrieval.api;
+
+import java.util.Collections;
+import org.apache.geaflow.ai.retrieval.api.model.ExecutionMode;
+import org.apache.geaflow.ai.retrieval.api.model.RetrievalBudget;
+import org.apache.geaflow.ai.retrieval.api.model.RetrievalCommand;
+import org.apache.geaflow.ai.retrieval.api.model.RetrievalErrorCode;
+import org.apache.geaflow.ai.retrieval.api.model.RetrievalException;
+import org.apache.geaflow.ai.retrieval.api.model.RetrievalMode;
+import org.apache.geaflow.ai.retrieval.api.model.RetrievalRequest;
+import org.apache.geaflow.ai.retrieval.config.RetrievalProperties;
+import org.apache.geaflow.ai.retrieval.service.RetrievalRequestValidator;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/** Tests the untrusted request to immutable command boundary. */
+public class RetrievalRequestValidatorTest {
+
+    @Test
+    public void appliesDefaultsAndTrimsInput() {
+        RetrievalRequest request = new RetrievalRequest();
+        request.setGraphName("  graph  ");
+        request.setQuery("  query  ");
+
+        RetrievalCommand command = validator().validate(request);
+
+        Assertions.assertEquals("graph", command.getGraphName());
+        Assertions.assertEquals("query", command.getQuery());
+        Assertions.assertEquals(RetrievalMode.KEYWORD, command.getMode());
+        Assertions.assertEquals(ExecutionMode.SEQUENTIAL, command.getExecutionMode());
+        Assertions.assertEquals(Integer.valueOf(10), command.getBudget().getTopK());
+        Assertions.assertEquals(Integer.valueOf(3000), command.getBudget().getTimeoutMs());
+        Assertions.assertEquals(Integer.valueOf(100), command.getBudget().getMaxCandidates());
+        Assertions.assertEquals(Integer.valueOf(4096), command.getBudget().getTokenBudget());
+    }
+
+    @Test
+    public void acceptsInclusiveBudgetBoundaries() {
+        RetrievalRequest request = request();
+        request.setBudget(new RetrievalBudget(100, 10000, 1000, 16384));
+
+        RetrievalCommand command = validator().validate(request);
+
+        Assertions.assertEquals(Integer.valueOf(100), command.getBudget().getTopK());
+        Assertions.assertEquals(Integer.valueOf(10000), command.getBudget().getTimeoutMs());
+        Assertions.assertEquals(Integer.valueOf(1000), command.getBudget().getMaxCandidates());
+        Assertions.assertEquals(Integer.valueOf(16384), command.getBudget().getTokenBudget());
+    }
+
+    @Test
+    public void rejectsMissingAndOverlongText() {
+        RetrievalRequest missingGraph = request();
+        missingGraph.setGraphName(" ");
+        assertCode(missingGraph, RetrievalErrorCode.INVALID_REQUEST);
+
+        RetrievalRequest missingQuery = request();
+        missingQuery.setQuery("\t");
+        assertCode(missingQuery, RetrievalErrorCode.INVALID_REQUEST);
+
+        RetrievalRequest longGraph = request();
+        longGraph.setGraphName(repeat('g', 129));
+        assertCode(longGraph, RetrievalErrorCode.INVALID_REQUEST);
+
+        RetrievalRequest longQuery = request();
+        longQuery.setQuery(repeat('q', 4097));
+        assertCode(longQuery, RetrievalErrorCode.INVALID_REQUEST);
+    }
+
+    @Test
+    public void rejectsUnsupportedModeExecutionAndVector() {
+        RetrievalRequest mode = request();
+        mode.setMode("HYBRID");
+        assertCode(mode, RetrievalErrorCode.UNSUPPORTED_OPTION);
+
+        RetrievalRequest execution = request();
+        execution.setExecutionMode("PARALLEL");
+        assertCode(execution, RetrievalErrorCode.UNSUPPORTED_OPTION);
+
+        RetrievalRequest unknownExecution = request();
+        unknownExecution.setExecutionMode("unknown");
+        assertCode(unknownExecution, RetrievalErrorCode.UNSUPPORTED_OPTION);
+
+        RetrievalRequest vector = request();
+        vector.setQueryVector(Collections.singletonList(0.1));
+        assertCode(vector, RetrievalErrorCode.UNSUPPORTED_OPTION);
+
+        RetrievalRequest emptyVector = request();
+        emptyVector.setQueryVector(Collections.<Double>emptyList());
+        Assertions.assertDoesNotThrow(() -> validator().validate(emptyVector));
+    }
+
+    @Test
+    public void rejectsBudgetRangesAndRelationships() {
+        assertBudget(new RetrievalBudget(0, 3000, 100, 4096));
+        assertBudget(new RetrievalBudget(101, 3000, 100, 4096));
+        assertBudget(new RetrievalBudget(10, 0, 100, 4096));
+        assertBudget(new RetrievalBudget(10, 10001, 100, 4096));
+        assertBudget(new RetrievalBudget(10, 3000, 0, 4096));
+        assertBudget(new RetrievalBudget(10, 3000, 1001, 4096));
+        assertBudget(new RetrievalBudget(10, 3000, 100, 0));
+        assertBudget(new RetrievalBudget(10, 3000, 100, 16385));
+        assertBudget(new RetrievalBudget(101, 3000, 100, 4096));
+    }
+
+    @Test
+    public void rejectsTopKGreaterThanCandidateBudget() {
+        RetrievalRequest request = request();
+        request.setBudget(new RetrievalBudget(20, 3000, 10, 4096));
+        assertCode(request, RetrievalErrorCode.INVALID_REQUEST);
+    }
+
+    @Test
+    public void commandCopiesBudgetValues() {
+        RetrievalBudget budget = new RetrievalBudget(5, 100, 10, 1000);
+        RetrievalRequest request = request();
+        request.setBudget(budget);
+        RetrievalCommand command = validator().validate(request);
+        RetrievalBudget commandBudget = command.getBudget();
+        commandBudget.setTopK(99);
+
+        Assertions.assertEquals(Integer.valueOf(5), command.getBudget().getTopK());
+    }
+
+    @Test
+    public void invalidPropertiesAreRejectedBeforeValidation() {
+        RetrievalProperties properties = properties();
+        properties.setDefaultTopK(101);
+        Assertions.assertThrows(RetrievalException.class, properties::validateConfiguration);
+
+        properties = properties();
+        properties.setDefaultTopK(101);
+        properties.setDefaultMaxCandidates(100);
+        RetrievalException exception = Assertions.assertThrows(RetrievalException.class,
+            properties::validateConfiguration);
+        Assertions.assertEquals(RetrievalErrorCode.INVALID_REQUEST, exception.getCode());
+    }
+
+    private static RetrievalRequest request() {
+        RetrievalRequest request = new RetrievalRequest();
+        request.setGraphName("graph");
+        request.setQuery("query");
+        return request;
+    }
+
+    private static RetrievalRequestValidator validator() {
+        RetrievalProperties properties = properties();
+        properties.validateConfiguration();
+        return new RetrievalRequestValidator(properties);
+    }
+
+    private static RetrievalProperties properties() {
+        return new RetrievalProperties();
+    }
+
+    private static void assertBudget(RetrievalBudget budget) {
+        RetrievalRequest request = request();
+        request.setBudget(budget);
+        assertCode(request, RetrievalErrorCode.INVALID_REQUEST);
+    }
+
+    private static void assertCode(RetrievalRequest request, RetrievalErrorCode code) {
+        RetrievalException exception = Assertions.assertThrows(RetrievalException.class,
+            () -> validator().validate(request));
+        Assertions.assertEquals(code, exception.getCode());
+    }
+
+    private static String repeat(char value, int count) {
+        StringBuilder builder = new StringBuilder(count);
+        for (int i = 0; i < count; i++) {
+            builder.append(value);
+        }
+        return builder.toString();
+    }
+}

--- a/geaflow-ai/src/test/resources/retrieval/api/error-index-not-ready.json
+++ b/geaflow-ai/src/test/resources/retrieval/api/error-index-not-ready.json
@@ -1,0 +1,6 @@
+{
+  "requestId": "request-2",
+  "code": "INDEX_NOT_READY",
+  "message": "retrieval index is not ready",
+  "retriable": true
+}

--- a/geaflow-ai/src/test/resources/retrieval/api/request-full.json
+++ b/geaflow-ai/src/test/resources/retrieval/api/request-full.json
@@ -1,0 +1,13 @@
+{
+  "graphName": "week1-keyword-graph",
+  "query": "Who is Confucius?",
+  "queryVector": [],
+  "mode": "KEYWORD",
+  "executionMode": "SEQUENTIAL",
+  "budget": {
+    "topK": 10,
+    "timeoutMs": 3000,
+    "maxCandidates": 100,
+    "tokenBudget": 4096
+  }
+}

--- a/geaflow-ai/src/test/resources/retrieval/api/response-empty.json
+++ b/geaflow-ai/src/test/resources/retrieval/api/response-empty.json
@@ -1,0 +1,23 @@
+{
+  "requestId": "request-1",
+  "graphName": "week1-keyword-graph",
+  "graphVersion": "v1",
+  "evidence": [],
+  "paths": [],
+  "sources": [],
+  "trace": {
+    "traceVersion": "v1",
+    "originalQuery": "unknown",
+    "selectedMode": "KEYWORD",
+    "executionMode": "SEQUENTIAL",
+    "stages": [],
+    "stopReason": "NO_EVIDENCE"
+  },
+  "effectiveBudget": {
+    "topK": 10,
+    "timeoutMs": 3000,
+    "maxCandidates": 100,
+    "tokenBudget": 4096
+  },
+  "degradedChannels": []
+}


### PR DESCRIPTION
## Summary

  Introduce the initial, versioned retrieval API contract for `geaflow-ai`.

  This PR defines the request, response, error, tracing, JSON boundary, and configuration model needed to expose retrieval capabilities safely. 

#860 #863 #864 

  ## Scope

  The v1 contract currently supports:

  - `KEYWORD` retrieval
  - `SEQUENTIAL` execution
  - Configurable request budgets
  - Versioned graph and index metadata
  - Evidence, graph path, source, and trace payloads
  - Stable machine-readable error responses

  `PARALLEL`, `CASCADED`, and query-vector retrieval are deliberately reserved for later versions and rejected as unsupported.

  ## Changes

  ### Retrieval API model

  - Add versioned request, command, response, budget, trace, stage, error, and exception models.
  - Define retrieval and execution mode enums.
  - Define stable retrieval error codes and retriable semantics.
  - Add graph/index version metadata to the API contract.

  ### JSON API boundary

  - Add strict JSON parsing and serialization for retrieval requests, responses, and errors.
  - Reject malformed JSON, duplicate fields, invalid enum values, invalid numeric fields, and missing required fields.
  - Preserve forward compatibility by accepting unknown JSON fields.
  - Ensure response collections are represented as arrays.
  - Add JSON fixtures for representative request, response, and error payloads.

  ### Configuration and validation

  - Add retrieval configuration properties and defaults in `application.yml`.
  - Validate configuration at startup.
  - Enforce the supported `config-version` value: `v1`.
  - Apply defaults to omitted request budget fields.
  - Enforce positive budgets, configured upper limits, and `topK <= maxCandidates`.
  - Validate success responses, traces, effective budgets, and error payload consistency before crossing the API boundary.

  ### Contract documentation

  - Document v1 supported modes and reserved options.
  - Document JSON compatibility rules.
  - Document HTTP mappings for retrieval error codes.